### PR TITLE
real time messaging showing twice issue

### DIFF
--- a/src/components/messages/chat-window.tsx
+++ b/src/components/messages/chat-window.tsx
@@ -110,6 +110,15 @@ export function ChatWindow({
           if (payload.new.receiver_id === otherUserId) {
             setMessages((prev) => {
               if (prev.some((m) => m.id === payload.new.id)) return prev;
+              // Replace optimistic temp message with real one
+              const tempIndex = prev.findIndex(
+                (m) => m.id.startsWith("temp-") && m.content === payload.new.content
+              );
+              if (tempIndex !== -1) {
+                const updated = [...prev];
+                updated[tempIndex] = payload.new as Message;
+                return updated;
+              }
               return [...prev, payload.new as Message];
             });
           }

--- a/src/components/sessions/session-chat.tsx
+++ b/src/components/sessions/session-chat.tsx
@@ -81,6 +81,15 @@ export function SessionChat({ sessionId, currentUserId }: SessionChatProps) {
           if (data) {
             setMessages((prev) => {
               if (prev.some((m) => m.id === data.id)) return prev;
+              // Replace optimistic temp message with real one
+              const tempIndex = prev.findIndex(
+                (m) => m.id.startsWith("temp-") && m.content === data.content
+              );
+              if (tempIndex !== -1) {
+                const updated = [...prev];
+                updated[tempIndex] = data;
+                return updated;
+              }
               return [...prev, data];
             });
           }


### PR DESCRIPTION
Root cause: When you send a message, it's added optimistically with id: "temp-123". Then the Realtime subscription fires with the real message (id: "uuid-abc"). The duplicate check prev.some(m => m.id === data.id) failed because "temp-123" !== "uuid-abc", so both showed up.

Fix: When a real message arrives via Realtime, it now looks for a matching temp message (same content, id starts with "temp-") and replaces it instead of adding a second one.

Fixed in both:

[chat-window.tsx](vscode-webview://1sepcjrmhdp7ke8ff9okg0un2kqfrhvrbc57pha135a39jlon81o/src/components/messages/chat-window.tsx) (DMs)
[session-chat.tsx](vscode-webview://1sepcjrmhdp7ke8ff9okg0un2kqfrhvrbc57pha135a39jlon81o/src/components/sessions/session-chat.tsx) (session group chat)