### PR TITLE
new feature added : getting informed according to Availability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "shuttlemates",
       "version": "0.1.0",
       "dependencies": {
+        "@react-email/components": "^1.0.7",
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.95.3",
         "class-variance-authority": "^0.7.1",
@@ -19,6 +20,7 @@
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "resend": "^6.9.2",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0"
       },
@@ -3286,6 +3288,316 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="
     },
+    "node_modules/@react-email/body": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@react-email/body/-/body-0.2.1.tgz",
+      "integrity": "sha512-ljDiQiJDu/Fq//vSIIP0z5Nuvt4+DX1RqGasstChDGJB/14ogd4VdNS9aacoede/ZjGy3o3Qb+cxyS+XgM6SwQ==",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/button": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@react-email/button/-/button-0.2.1.tgz",
+      "integrity": "sha512-qXyj7RZLE7POy9BMKSoqQ00tOXThjOZSUnI2Yu9i29IHngPlmrNayIWBoVKtElES7OWwypUcpiajwi1mUWx6/A==",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/code-block": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@react-email/code-block/-/code-block-0.2.1.tgz",
+      "integrity": "sha512-M3B7JpVH4ytgn83/ujRR1k1DQHvTeABiDM61OvAbjLRPhC/5KLHU5KkzIbbuGIrjWwxAbL1kSQzU8MhLEtSxyw==",
+      "dependencies": {
+        "prismjs": "^1.30.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/code-inline": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@react-email/code-inline/-/code-inline-0.0.6.tgz",
+      "integrity": "sha512-jfhebvv3dVsp3OdPgKXnk8+e2pBiDVZejDOBFzBa/IblrAJ9cQDkN6rBD5IyEg8hTOxwbw3iaI/yZFmDmIguIA==",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/column": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@react-email/column/-/column-0.0.14.tgz",
+      "integrity": "sha512-f+W+Bk2AjNO77zynE33rHuQhyqVICx4RYtGX9NKsGUg0wWjdGP0qAuIkhx9Rnmk4/hFMo1fUrtYNqca9fwJdHg==",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/components": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@react-email/components/-/components-1.0.7.tgz",
+      "integrity": "sha512-mY+v4C1SMaGOKuKp0QWDQLGK+3fvH06ZE10EVavv+T6tQneDHq9cpQ9NdCrvuO1nWZnWrA/0tRpvyqyF0uo93w==",
+      "dependencies": {
+        "@react-email/body": "0.2.1",
+        "@react-email/button": "0.2.1",
+        "@react-email/code-block": "0.2.1",
+        "@react-email/code-inline": "0.0.6",
+        "@react-email/column": "0.0.14",
+        "@react-email/container": "0.0.16",
+        "@react-email/font": "0.0.10",
+        "@react-email/head": "0.0.13",
+        "@react-email/heading": "0.0.16",
+        "@react-email/hr": "0.0.12",
+        "@react-email/html": "0.0.12",
+        "@react-email/img": "0.0.12",
+        "@react-email/link": "0.0.13",
+        "@react-email/markdown": "0.0.18",
+        "@react-email/preview": "0.0.14",
+        "@react-email/render": "2.0.4",
+        "@react-email/row": "0.0.13",
+        "@react-email/section": "0.0.17",
+        "@react-email/tailwind": "2.0.4",
+        "@react-email/text": "0.1.6"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/components/node_modules/@react-email/render": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@react-email/render/-/render-2.0.4.tgz",
+      "integrity": "sha512-kht2oTFQ1SwrLpd882ahTvUtNa9s53CERHstiTbzhm6aR2Hbykp/mQ4tpPvsBGkKAEvKRlDEoooh60Uk6nHK1g==",
+      "dependencies": {
+        "html-to-text": "^9.0.5",
+        "prettier": "^3.5.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/container": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@react-email/container/-/container-0.0.16.tgz",
+      "integrity": "sha512-QWBB56RkkU0AJ9h+qy33gfT5iuZknPC7Un/IjZv9B0QmMIK+WWacc0cH6y2SV5Cv/b99hU94fjEMOOO4enpkbQ==",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/font": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@react-email/font/-/font-0.0.10.tgz",
+      "integrity": "sha512-0urVSgCmQIfx5r7Xc586miBnQUVnGp3OTYUm8m5pwtQRdTRO5XrTtEfNJ3JhYhSOruV0nD8fd+dXtKXobum6tA==",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/head": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@react-email/head/-/head-0.0.13.tgz",
+      "integrity": "sha512-AJg6le/08Gz4tm+6MtKXqtNNyKHzmooOCdmtqmWxD7FxoAdU1eVcizhtQ0gcnVaY6ethEyE/hnEzQxt1zu5Kog==",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/heading": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@react-email/heading/-/heading-0.0.16.tgz",
+      "integrity": "sha512-jmsKnQm1ykpBzw4hCYHwBkt5pW2jScXffPeEH5ZRF5tZeF5b1pvlFTO9han7C0pCkZYo1kEvWiRtx69yfCIwuw==",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/hr": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@react-email/hr/-/hr-0.0.12.tgz",
+      "integrity": "sha512-TwmOmBDibavUQpXBxpmZYi2Iks/yeZOzFYh+di9EltMSnEabH8dMZXrl+pxNXzCgZ2XE8HY7VmUL65Lenfu5PA==",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/html": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@react-email/html/-/html-0.0.12.tgz",
+      "integrity": "sha512-KTShZesan+UsreU7PDUV90afrZwU5TLwYlALuCSU0OT+/U8lULNNbAUekg+tGwCnOfIKYtpDPKkAMRdYlqUznw==",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/img": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@react-email/img/-/img-0.0.12.tgz",
+      "integrity": "sha512-sRCpEARNVTf3FQhZOC+JTvu5r6ubiYWkT0ucYXg8ctkyi4G8QG+jgYPiNUqVeTLA2STOfmPM/nrk1nb84y6CPQ==",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/link": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@react-email/link/-/link-0.0.13.tgz",
+      "integrity": "sha512-lkWc/NjOcefRZMkQoSDDbuKBEBDES9aXnFEOuPH845wD3TxPwh+QTf0fStuzjoRLUZWpHnio4z7qGGRYusn/sw==",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/markdown": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@react-email/markdown/-/markdown-0.0.18.tgz",
+      "integrity": "sha512-gSuYK5fsMbGk87jDebqQ6fa2fKcWlkf2Dkva8kMONqLgGCq8/0d+ZQYMEJsdidIeBo3kmsnHZPrwdFB4HgjUXg==",
+      "dependencies": {
+        "marked": "^15.0.12"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/preview": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@react-email/preview/-/preview-0.0.14.tgz",
+      "integrity": "sha512-aYK8q0IPkBXyMsbpMXgxazwHxYJxTrXrV95GFuu2HbEiIToMwSyUgb8HDFYwPqqfV03/jbwqlsXmFxsOd+VNaw==",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/row": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@react-email/row/-/row-0.0.13.tgz",
+      "integrity": "sha512-bYnOac40vIKCId7IkwuLAAsa3fKfSfqCvv6epJKmPE0JBuu5qI4FHFCl9o9dVpIIS08s/ub+Y/txoMt0dYziGw==",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/section": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/@react-email/section/-/section-0.0.17.tgz",
+      "integrity": "sha512-qNl65ye3W0Rd5udhdORzTV9ezjb+GFqQQSae03NDzXtmJq6sqVXNWNiVolAjvJNypim+zGXmv6J9TcV5aNtE/w==",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/tailwind": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@react-email/tailwind/-/tailwind-2.0.4.tgz",
+      "integrity": "sha512-cDp8Ss6LJKI8zBLKE+tsXFurn6I2nnQNg1qqjfZuNPNoToN1Uyx3egW0bwSVk1JjrNWx/Xnme7ZxvNLRrU9K0Q==",
+      "dependencies": {
+        "tailwindcss": "^4.1.18"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@react-email/body": "0.2.1",
+        "@react-email/button": "0.2.1",
+        "@react-email/code-block": "0.2.1",
+        "@react-email/code-inline": "0.0.6",
+        "@react-email/container": "0.0.16",
+        "@react-email/heading": "0.0.16",
+        "@react-email/hr": "0.0.12",
+        "@react-email/img": "0.0.12",
+        "@react-email/link": "0.0.13",
+        "@react-email/preview": "0.0.14",
+        "@react-email/text": "0.1.6",
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/body": {
+          "optional": true
+        },
+        "@react-email/button": {
+          "optional": true
+        },
+        "@react-email/code-block": {
+          "optional": true
+        },
+        "@react-email/code-inline": {
+          "optional": true
+        },
+        "@react-email/container": {
+          "optional": true
+        },
+        "@react-email/heading": {
+          "optional": true
+        },
+        "@react-email/hr": {
+          "optional": true
+        },
+        "@react-email/img": {
+          "optional": true
+        },
+        "@react-email/link": {
+          "optional": true
+        },
+        "@react-email/preview": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-email/text": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@react-email/text/-/text-0.1.6.tgz",
+      "integrity": "sha512-TYqkioRS45wTR5il3dYk/SbUjjEdhSwh9BtRNB99qNH1pXAwA45H7rAuxehiu8iJQJH0IyIr+6n62gBz9ezmsw==",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3298,6 +3610,18 @@
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
       "dev": true
     },
+    "node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "selderee": "^0.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
@@ -3309,6 +3633,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.95.3",
@@ -5288,7 +5617,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5411,6 +5739,57 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "17.2.4",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.4.tgz",
@@ -5492,6 +5871,17 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -6296,6 +6686,11 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -6871,6 +7266,39 @@
       "dev": true,
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/html-to-text": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "^0.11.0",
+        "deepmerge": "^4.3.1",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.2",
+        "selderee": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
       }
     },
     "node_modules/http-errors": {
@@ -7740,6 +8168,14 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/leac": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -8105,6 +8541,17 @@
       "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {
@@ -8831,6 +9278,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parseley": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "dependencies": {
+        "leac": "^0.6.0",
+        "peberminta": "^0.9.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -8876,6 +9335,14 @@
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "dev": true
     },
+    "node_modules/peberminta": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8910,6 +9377,11 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/postal-mime": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.3.tgz",
+      "integrity": "sha512-MjhXadAJaWgYzevi46+3kLak8y6gbg0ku14O1gO/LNOuay8dO+1PtcSGvAdgDR0DoIsSaiIA8y/Ddw6MnrO0Tw=="
     },
     "node_modules/postcss": {
       "version": "8.5.6",
@@ -8973,6 +9445,20 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
@@ -8986,6 +9472,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/prompts": {
@@ -9345,6 +9839,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resend": {
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.9.2.tgz",
+      "integrity": "sha512-uIM6CQ08tS+hTCRuKBFbOBvHIGaEhqZe8s4FOgqsVXSbQLAhmNWpmUhG3UAtRnmcwTWFUqnHa/+Vux8YGPyDBA==",
+      "dependencies": {
+        "postal-mime": "2.7.3",
+        "svix": "1.84.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -9538,6 +10052,17 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
+    },
+    "node_modules/selderee": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "dependencies": {
+        "parseley": "^0.12.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -9941,6 +10466,15 @@
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -10222,6 +10756,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svix": {
+      "version": "1.84.1",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.84.1.tgz",
+      "integrity": "sha512-K8DPPSZaW/XqXiz1kEyzSHYgmGLnhB43nQCMeKjWGCUpLIpAMMM8kx3rVVOSm6Bo6EHyK1RQLPT4R06skM/MlQ==",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
+      }
+    },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
@@ -10246,8 +10789,7 @@
     "node_modules/tailwindcss": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
-      "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-      "dev": true
+      "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw=="
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -10773,6 +11315,18 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/validate-npm-package-name": {
       "version": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@react-email/components": "^1.0.7",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.95.3",
     "class-variance-authority": "^0.7.1",
@@ -20,6 +21,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "resend": "^6.9.2",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0"
   },

--- a/src/app/(protected)/availability/page.tsx
+++ b/src/app/(protected)/availability/page.tsx
@@ -1,0 +1,74 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { SpecificAvailabilityForm } from "@/components/availability/specific-availability-form";
+import { RecurringAvailabilityForm } from "@/components/availability/recurring-availability-form";
+import { AvailabilityList } from "@/components/availability/availability-list";
+import { NotificationToggle } from "@/components/availability/notification-toggle";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+export default async function AvailabilityPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/login");
+
+  const [{ data: profile }, { data: specificSlots }, { data: recurringSlots }] =
+    await Promise.all([
+      supabase
+        .from("profiles")
+        .select("city, email_notifications")
+        .eq("id", user.id)
+        .single(),
+      supabase
+        .from("availability_specific")
+        .select("*")
+        .eq("user_id", user.id)
+        .gte("date", new Date().toISOString().split("T")[0])
+        .order("date", { ascending: true }),
+      supabase
+        .from("availability_recurring")
+        .select("*")
+        .eq("user_id", user.id)
+        .order("day_of_week", { ascending: true }),
+    ]);
+
+  return (
+    <div className="container max-w-2xl mx-auto py-8 px-4">
+      <h1 className="text-3xl font-bold mb-2">My Availability</h1>
+      <p className="text-muted-foreground mb-6">
+        Set when you are free to play. You will be notified by email when a
+        session is created that matches your availability and city.
+      </p>
+
+      <div className="space-y-6">
+        <NotificationToggle
+          enabled={profile?.email_notifications ?? true}
+        />
+
+        <Tabs defaultValue="specific">
+          <TabsList>
+            <TabsTrigger value="specific">Specific Dates</TabsTrigger>
+            <TabsTrigger value="recurring">Weekly Recurring</TabsTrigger>
+          </TabsList>
+          <TabsContent value="specific" className="mt-4">
+            <SpecificAvailabilityForm
+              defaultCity={profile?.city ?? undefined}
+            />
+          </TabsContent>
+          <TabsContent value="recurring" className="mt-4">
+            <RecurringAvailabilityForm
+              defaultCity={profile?.city ?? undefined}
+            />
+          </TabsContent>
+        </Tabs>
+
+        <AvailabilityList
+          specificSlots={specificSlots ?? []}
+          recurringSlots={recurringSlots ?? []}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/availability/availability-list.tsx
+++ b/src/components/availability/availability-list.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useState } from "react";
+import {
+  removeSpecificAvailability,
+  removeRecurringAvailability,
+} from "@/lib/actions/availability";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Trash2, Calendar, Repeat } from "lucide-react";
+import { format } from "date-fns";
+import { toast } from "sonner";
+import type {
+  AvailabilitySpecific,
+  AvailabilityRecurring,
+} from "@/lib/types/database";
+
+const DAY_NAMES = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
+
+interface AvailabilityListProps {
+  specificSlots: AvailabilitySpecific[];
+  recurringSlots: AvailabilityRecurring[];
+}
+
+export function AvailabilityList({
+  specificSlots,
+  recurringSlots,
+}: AvailabilityListProps) {
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const handleDeleteSpecific = async (id: string) => {
+    setDeletingId(id);
+    try {
+      await removeSpecificAvailability(id);
+      toast.success("Availability removed");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to remove"
+      );
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const handleDeleteRecurring = async (id: string) => {
+    setDeletingId(id);
+    try {
+      await removeRecurringAvailability(id);
+      toast.success("Availability removed");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to remove"
+      );
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const hasSlots = specificSlots.length > 0 || recurringSlots.length > 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">Your Availability</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {!hasSlots && (
+          <p className="text-muted-foreground text-sm">
+            No availability set yet. Add your available times above to get
+            notified when matching sessions are created.
+          </p>
+        )}
+
+        {recurringSlots.length > 0 && (
+          <div className="space-y-2 mb-4">
+            <p className="text-sm font-medium text-muted-foreground flex items-center gap-2">
+              <Repeat className="h-4 w-4" /> Weekly Recurring
+            </p>
+            {recurringSlots.map((slot) => (
+              <div
+                key={slot.id}
+                className="flex items-center justify-between p-3 rounded-md border"
+              >
+                <div className="flex items-center gap-2 flex-wrap">
+                  <Badge variant="secondary">
+                    {DAY_NAMES[slot.day_of_week]}
+                  </Badge>
+                  <span className="text-sm">
+                    {slot.start_time.slice(0, 5)} -{" "}
+                    {slot.end_time.slice(0, 5)}
+                  </span>
+                  <span className="text-sm text-muted-foreground">
+                    in {slot.city}
+                  </span>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                  onClick={() => handleDeleteRecurring(slot.id)}
+                  disabled={deletingId === slot.id}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {specificSlots.length > 0 && (
+          <div className="space-y-2">
+            <p className="text-sm font-medium text-muted-foreground flex items-center gap-2">
+              <Calendar className="h-4 w-4" /> Specific Dates
+            </p>
+            {specificSlots.map((slot) => (
+              <div
+                key={slot.id}
+                className="flex items-center justify-between p-3 rounded-md border"
+              >
+                <div className="flex items-center gap-2 flex-wrap">
+                  <Badge variant="outline">
+                    {format(
+                      new Date(slot.date + "T00:00:00"),
+                      "EEE, MMM d"
+                    )}
+                  </Badge>
+                  <span className="text-sm">
+                    {slot.start_time.slice(0, 5)} -{" "}
+                    {slot.end_time.slice(0, 5)}
+                  </span>
+                  <span className="text-sm text-muted-foreground">
+                    in {slot.city}
+                  </span>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                  onClick={() => handleDeleteSpecific(slot.id)}
+                  disabled={deletingId === slot.id}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/availability/notification-toggle.tsx
+++ b/src/components/availability/notification-toggle.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import { updateNotificationPreference } from "@/lib/actions/availability";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { toast } from "sonner";
+import { Mail } from "lucide-react";
+
+interface NotificationToggleProps {
+  enabled: boolean;
+}
+
+export function NotificationToggle({
+  enabled: initialEnabled,
+}: NotificationToggleProps) {
+  const [enabled, setEnabled] = useState(initialEnabled);
+  const [loading, setLoading] = useState(false);
+
+  const handleChange = async (checked: boolean) => {
+    setLoading(true);
+    setEnabled(checked);
+    try {
+      await updateNotificationPreference(checked);
+      toast.success(
+        checked
+          ? "Email notifications enabled"
+          : "Email notifications disabled"
+      );
+    } catch (err) {
+      setEnabled(!checked);
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : "Failed to update preference"
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-between p-4 border rounded-lg">
+      <div className="flex items-center gap-3">
+        <Mail className="h-5 w-5 text-muted-foreground" />
+        <div>
+          <Label htmlFor="email-notifications" className="font-medium">
+            Email Notifications
+          </Label>
+          <p className="text-sm text-muted-foreground">
+            Get notified when sessions match your availability
+          </p>
+        </div>
+      </div>
+      <Switch
+        id="email-notifications"
+        checked={enabled}
+        onCheckedChange={handleChange}
+        disabled={loading}
+      />
+    </div>
+  );
+}

--- a/src/components/availability/recurring-availability-form.tsx
+++ b/src/components/availability/recurring-availability-form.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useState } from "react";
+import { addRecurringAvailability } from "@/lib/actions/availability";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "sonner";
+
+const DAYS = [
+  { value: "0", label: "Sunday" },
+  { value: "1", label: "Monday" },
+  { value: "2", label: "Tuesday" },
+  { value: "3", label: "Wednesday" },
+  { value: "4", label: "Thursday" },
+  { value: "5", label: "Friday" },
+  { value: "6", label: "Saturday" },
+];
+
+interface RecurringAvailabilityFormProps {
+  defaultCity?: string;
+}
+
+export function RecurringAvailabilityForm({
+  defaultCity,
+}: RecurringAvailabilityFormProps) {
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (formData: FormData) => {
+    setLoading(true);
+    try {
+      await addRecurringAvailability(formData);
+      toast.success("Recurring availability added!");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Something went wrong"
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Add Weekly Recurring</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form action={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label>Day of Week</Label>
+            <Select name="day_of_week" defaultValue="1">
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {DAYS.map((day) => (
+                  <SelectItem key={day.value} value={day.value}>
+                    {day.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="recurring-start">From</Label>
+              <Input
+                id="recurring-start"
+                name="start_time"
+                type="time"
+                defaultValue="18:00"
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="recurring-end">To</Label>
+              <Input
+                id="recurring-end"
+                name="end_time"
+                type="time"
+                defaultValue="21:00"
+                required
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="recurring-city">City</Label>
+            <Input
+              id="recurring-city"
+              name="city"
+              defaultValue={defaultCity ?? ""}
+              placeholder="e.g., Colombo"
+              required
+            />
+          </div>
+          <Button type="submit" className="w-full" disabled={loading}>
+            {loading ? "Adding..." : "Add Recurring Day"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/availability/specific-availability-form.tsx
+++ b/src/components/availability/specific-availability-form.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState } from "react";
+import { addSpecificAvailability } from "@/lib/actions/availability";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { toast } from "sonner";
+
+interface SpecificAvailabilityFormProps {
+  defaultCity?: string;
+}
+
+export function SpecificAvailabilityForm({
+  defaultCity,
+}: SpecificAvailabilityFormProps) {
+  const [loading, setLoading] = useState(false);
+
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const defaultDate = tomorrow.toISOString().split("T")[0];
+
+  const handleSubmit = async (formData: FormData) => {
+    setLoading(true);
+    try {
+      await addSpecificAvailability(formData);
+      toast.success("Availability added!");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Something went wrong"
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Add Specific Date</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form action={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="specific-date">Date</Label>
+            <Input
+              id="specific-date"
+              name="date"
+              type="date"
+              defaultValue={defaultDate}
+              min={new Date().toISOString().split("T")[0]}
+              required
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="specific-start">From</Label>
+              <Input
+                id="specific-start"
+                name="start_time"
+                type="time"
+                defaultValue="18:00"
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="specific-end">To</Label>
+              <Input
+                id="specific-end"
+                name="end_time"
+                type="time"
+                defaultValue="21:00"
+                required
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="specific-city">City</Label>
+            <Input
+              id="specific-city"
+              name="city"
+              defaultValue={defaultCity ?? ""}
+              placeholder="e.g., Colombo"
+              required
+            />
+          </div>
+          <Button type="submit" className="w-full" disabled={loading}>
+            {loading ? "Adding..." : "Add Date"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -21,7 +21,7 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { Badge } from "@/components/ui/badge";
-import { Menu, LogOut, User, Calendar, Plus, MessageCircle, Sun, Moon } from "lucide-react";
+import { Menu, LogOut, User, Calendar, Plus, MessageCircle, Clock, Sun, Moon } from "lucide-react";
 
 interface NavbarProps {
   userName: string | null;
@@ -53,6 +53,7 @@ export function Navbar({ userName, avatarUrl, unreadMessageCount = 0 }: NavbarPr
     { href: "/sessions", label: "Find Sessions", icon: Calendar },
     { href: "/sessions/new", label: "Create Session", icon: Plus },
     { href: "/my-sessions", label: "My Sessions", icon: Calendar },
+    { href: "/availability", label: "Availability", icon: Clock },
     { href: "/messages", label: "Messages", icon: MessageCircle },
   ];
 

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import * as React from "react"
+import { Switch as SwitchPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block rounded-full ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
+        )}
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/src/lib/actions/availability.ts
+++ b/src/lib/actions/availability.ts
@@ -1,0 +1,132 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { revalidatePath } from "next/cache";
+
+// --- Specific-date availability ---
+
+export async function addSpecificAvailability(formData: FormData) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("Not authenticated");
+
+  const date = formData.get("date") as string;
+  const start_time = formData.get("start_time") as string;
+  const end_time = formData.get("end_time") as string;
+  const city = formData.get("city") as string;
+
+  if (!date || !start_time || !end_time || !city) {
+    throw new Error("All fields are required");
+  }
+  if (end_time <= start_time) {
+    throw new Error("End time must be after start time");
+  }
+
+  const { error } = await supabase.from("availability_specific").insert({
+    user_id: user.id,
+    date,
+    start_time,
+    end_time,
+    city,
+  });
+
+  if (error) {
+    if (error.code === "23505")
+      throw new Error("This time slot already exists");
+    throw new Error(error.message);
+  }
+
+  revalidatePath("/availability");
+}
+
+export async function removeSpecificAvailability(id: string) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("Not authenticated");
+
+  const { error } = await supabase
+    .from("availability_specific")
+    .delete()
+    .eq("id", id)
+    .eq("user_id", user.id);
+
+  if (error) throw new Error(error.message);
+  revalidatePath("/availability");
+}
+
+// --- Recurring weekly availability ---
+
+export async function addRecurringAvailability(formData: FormData) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("Not authenticated");
+
+  const day_of_week = parseInt(formData.get("day_of_week") as string);
+  const start_time = formData.get("start_time") as string;
+  const end_time = formData.get("end_time") as string;
+  const city = formData.get("city") as string;
+
+  if (isNaN(day_of_week) || !start_time || !end_time || !city) {
+    throw new Error("All fields are required");
+  }
+  if (end_time <= start_time) {
+    throw new Error("End time must be after start time");
+  }
+
+  const { error } = await supabase.from("availability_recurring").insert({
+    user_id: user.id,
+    day_of_week,
+    start_time,
+    end_time,
+    city,
+  });
+
+  if (error) {
+    if (error.code === "23505")
+      throw new Error("This time slot already exists");
+    throw new Error(error.message);
+  }
+
+  revalidatePath("/availability");
+}
+
+export async function removeRecurringAvailability(id: string) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("Not authenticated");
+
+  const { error } = await supabase
+    .from("availability_recurring")
+    .delete()
+    .eq("id", id)
+    .eq("user_id", user.id);
+
+  if (error) throw new Error(error.message);
+  revalidatePath("/availability");
+}
+
+// --- Notification preferences ---
+
+export async function updateNotificationPreference(enabled: boolean) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("Not authenticated");
+
+  const { error } = await supabase
+    .from("profiles")
+    .update({ email_notifications: enabled })
+    .eq("id", user.id);
+
+  if (error) throw new Error(error.message);
+  revalidatePath("/availability");
+}

--- a/src/lib/actions/notifications.ts
+++ b/src/lib/actions/notifications.ts
@@ -1,0 +1,136 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import { resend } from "@/lib/email/resend";
+import { format } from "date-fns";
+
+interface SessionData {
+  id: string;
+  creator_id: string;
+  title: string;
+  date: string;
+  time: string;
+  location: string;
+  city: string;
+  skill_level: string;
+  game_type: string;
+}
+
+export async function notifyMatchingPlayers(session: SessionData) {
+  const admin = createAdminClient();
+
+  // Determine the day of week for the session date (0=Sun, 6=Sat)
+  const sessionDate = new Date(session.date + "T00:00:00");
+  const dayOfWeek = sessionDate.getDay();
+
+  // Find users with specific-date availability matching this session
+  // Use %city% pattern so "Malabe" matches "Colombo, Gampaha, Malabe"
+  const { data: specificMatches } = await admin
+    .from("availability_specific")
+    .select("user_id")
+    .eq("date", session.date)
+    .ilike("city", `%${session.city}%`)
+    .lte("start_time", session.time)
+    .gte("end_time", session.time)
+    .neq("user_id", session.creator_id);
+
+  // Find users with recurring availability matching this session
+  const { data: recurringMatches } = await admin
+    .from("availability_recurring")
+    .select("user_id")
+    .eq("day_of_week", dayOfWeek)
+    .ilike("city", `%${session.city}%`)
+    .lte("start_time", session.time)
+    .gte("end_time", session.time)
+    .neq("user_id", session.creator_id);
+
+  // Deduplicate user IDs
+  const matchedUserIds = new Set<string>();
+  specificMatches?.forEach((m) => matchedUserIds.add(m.user_id));
+  recurringMatches?.forEach((m) => matchedUserIds.add(m.user_id));
+
+  if (matchedUserIds.size === 0) return;
+
+  // Get profiles with notifications enabled
+  const { data: profiles } = await admin
+    .from("profiles")
+    .select("id, full_name, email_notifications")
+    .in("id", Array.from(matchedUserIds))
+    .eq("email_notifications", true);
+
+  if (!profiles || profiles.length === 0) return;
+
+  // Get emails from auth.users
+  const { data: authData } = await admin.auth.admin.listUsers();
+  const emailMap = new Map<string, string>();
+  authData?.users?.forEach((u) => {
+    if (u.email) emailMap.set(u.id, u.email);
+  });
+
+  // Filter out already-notified users
+  const { data: existingNotifications } = await admin
+    .from("notification_log")
+    .select("user_id")
+    .eq("session_id", session.id)
+    .in("user_id", Array.from(matchedUserIds));
+
+  const alreadyNotified = new Set(
+    existingNotifications?.map((n) => n.user_id) ?? []
+  );
+
+  // Prepare email data
+  const appUrl =
+    process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+  const formattedDate = format(sessionDate, "EEEE, MMMM d, yyyy");
+  const notificationInserts: {
+    user_id: string;
+    session_id: string;
+    type: string;
+  }[] = [];
+
+  // Send emails
+  for (const profile of profiles) {
+    if (alreadyNotified.has(profile.id)) continue;
+
+    const email = emailMap.get(profile.id);
+    if (!email) continue;
+
+    try {
+      const playerName = profile.full_name ?? "Player";
+      const sessionUrl = `${appUrl}/sessions/${session.id}`;
+
+      await resend.emails.send({
+        from: "ShuttleMates <onboarding@resend.dev>",
+        to: email,
+        subject: `New session matches your availability: ${session.title}`,
+        html: `
+          <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
+            <h2 style="color: #1a1a1a; margin: 0 0 16px 0;">New session matches your availability!</h2>
+            <p style="color: #374151; margin: 0 0 8px 0;">Hi ${playerName},</p>
+            <p style="color: #374151; margin: 0 0 16px 0;">A new badminton session has been created that fits your schedule:</p>
+            <div style="background: #f4f4f5; border-radius: 8px; padding: 16px; margin: 0 0 20px 0;">
+              <h3 style="margin: 0 0 12px 0; color: #1a1a1a;">${session.title}</h3>
+              <p style="margin: 4px 0; color: #374151; font-size: 14px;">Date: ${formattedDate}</p>
+              <p style="margin: 4px 0; color: #374151; font-size: 14px;">Time: ${session.time.slice(0, 5)}</p>
+              <p style="margin: 4px 0; color: #374151; font-size: 14px;">Location: ${session.location}, ${session.city}</p>
+              <p style="margin: 4px 0; color: #374151; font-size: 14px;">Level: ${session.skill_level} | Type: ${session.game_type}</p>
+            </div>
+            <a href="${sessionUrl}" style="display: inline-block; background: #18181b; color: #ffffff; padding: 10px 24px; border-radius: 6px; text-decoration: none; font-weight: bold; font-size: 14px;">View Session</a>
+            <p style="color: #9ca3af; font-size: 12px; margin-top: 24px;">You received this because your availability matches this session. Manage your preferences in ShuttleMates availability settings.</p>
+          </div>
+        `,
+      });
+
+      notificationInserts.push({
+        user_id: profile.id,
+        session_id: session.id,
+        type: "session_match",
+      });
+    } catch (err) {
+      console.error(`Failed to send notification to ${profile.id}:`, err);
+    }
+  }
+
+  // Log successful notifications
+  if (notificationInserts.length > 0) {
+    await admin.from("notification_log").insert(notificationInserts);
+  }
+}

--- a/src/lib/actions/sessions.ts
+++ b/src/lib/actions/sessions.ts
@@ -40,6 +40,26 @@ export async function createSession(formData: FormData) {
     user_id: user.id,
   });
 
+  // Notify players whose availability matches this session
+  try {
+    const { notifyMatchingPlayers } = await import(
+      "@/lib/actions/notifications"
+    );
+    await notifyMatchingPlayers({
+      id: data.id,
+      creator_id: user.id,
+      title: sessionData.title,
+      date: sessionData.date,
+      time: sessionData.time,
+      location: sessionData.location,
+      city: sessionData.city,
+      skill_level: sessionData.skill_level,
+      game_type: sessionData.game_type,
+    });
+  } catch (err) {
+    console.error("Failed to send availability notifications:", err);
+  }
+
   revalidatePath("/sessions");
   redirect(`/sessions/${data.id}`);
 }

--- a/src/lib/email/resend.ts
+++ b/src/lib/email/resend.ts
@@ -1,0 +1,3 @@
+import { Resend } from "resend";
+
+export const resend = new Resend(process.env.RESEND_API_KEY);

--- a/src/lib/email/templates/session-match.tsx
+++ b/src/lib/email/templates/session-match.tsx
@@ -1,0 +1,95 @@
+import * as React from "react";
+
+interface SessionMatchEmailProps {
+  playerName: string;
+  sessionTitle: string;
+  sessionDate: string;
+  sessionTime: string;
+  sessionLocation: string;
+  sessionCity: string;
+  skillLevel: string;
+  gameType: string;
+  sessionUrl: string;
+}
+
+export function SessionMatchEmail({
+  playerName,
+  sessionTitle,
+  sessionDate,
+  sessionTime,
+  sessionLocation,
+  sessionCity,
+  skillLevel,
+  gameType,
+  sessionUrl,
+}: SessionMatchEmailProps) {
+  return (
+    <div
+      style={{
+        fontFamily: "Arial, sans-serif",
+        maxWidth: 600,
+        margin: "0 auto",
+        padding: 24,
+      }}
+    >
+      <h2 style={{ color: "#1a1a1a", margin: "0 0 16px 0" }}>
+        New session matches your availability!
+      </h2>
+      <p style={{ color: "#374151", margin: "0 0 8px 0" }}>Hi {playerName},</p>
+      <p style={{ color: "#374151", margin: "0 0 16px 0" }}>
+        A new badminton session has been created that fits your schedule:
+      </p>
+      <div
+        style={{
+          background: "#f4f4f5",
+          borderRadius: 8,
+          padding: 16,
+          margin: "0 0 20px 0",
+        }}
+      >
+        <h3 style={{ margin: "0 0 12px 0", color: "#1a1a1a" }}>
+          {sessionTitle}
+        </h3>
+        <p style={{ margin: "4px 0", color: "#374151", fontSize: 14 }}>
+          Date: {sessionDate}
+        </p>
+        <p style={{ margin: "4px 0", color: "#374151", fontSize: 14 }}>
+          Time: {sessionTime}
+        </p>
+        <p style={{ margin: "4px 0", color: "#374151", fontSize: 14 }}>
+          Location: {sessionLocation}, {sessionCity}
+        </p>
+        <p style={{ margin: "4px 0", color: "#374151", fontSize: 14 }}>
+          Level: {skillLevel} | Type: {gameType}
+        </p>
+      </div>
+      <a
+        href={sessionUrl}
+        style={{
+          display: "inline-block",
+          background: "#18181b",
+          color: "#ffffff",
+          padding: "10px 24px",
+          borderRadius: 6,
+          textDecoration: "none",
+          fontWeight: "bold",
+          fontSize: 14,
+        }}
+      >
+        View Session
+      </a>
+      <p
+        style={{
+          color: "#9ca3af",
+          fontSize: 12,
+          marginTop: 24,
+          marginBottom: 0,
+        }}
+      >
+        You received this because your availability matches this session. You
+        can manage your notification preferences in your ShuttleMates
+        availability settings.
+      </p>
+    </div>
+  );
+}

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -1,0 +1,8 @@
+import { createClient } from "@supabase/supabase-js";
+
+export function createAdminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+}

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -67,3 +67,23 @@ export interface SessionWithParticipants extends SessionWithCreator {
     profiles: Pick<Profile, "id" | "full_name" | "avatar_url" | "skill_level">;
   })[];
 }
+
+export interface AvailabilitySpecific {
+  id: string;
+  user_id: string;
+  date: string;
+  start_time: string;
+  end_time: string;
+  city: string;
+  created_at: string;
+}
+
+export interface AvailabilityRecurring {
+  id: string;
+  user_id: string;
+  day_of_week: number;
+  start_time: string;
+  end_time: string;
+  city: string;
+  created_at: string;
+}


### PR DESCRIPTION
## Feature: Player Availability & Email Notifications

### What was implemented

**Availability Settings** — Players can now set when they're free to play via a new `/availability` page:
- **Specific dates** — Pick a date + time range + city (e.g., "Feb 15, 6pm-9pm, Malabe")
- **Weekly recurring** — Pick a day of the week + time range + city (e.g., "Every Monday, 6pm-9pm, Malabe")
- **Notification toggle** — Opt in/out of email notifications with a switch

**Email Notifications** — When a session is created that matches a player's availability (date/time overlap + same city), they receive an email via Resend with session details and a "View Session" link.

---

### Technical Details

- **3 new database tables**: `availability_specific`, `availability_recurring`, `notification_log` (with RLS policies and indexes)
- **1 altered table**: `profiles` — added `email_notifications` boolean column
- **Matching logic**: Runs inside `createSession()` server action. Queries both availability tables, deduplicates matches, filters by notification preference, checks for already-sent notifications, and sends emails. Wrapped in `try/catch` so email failures never break session creation.
- **Email service**: [Resend](https://resend.com) (free tier — 100 emails/day)
- **Admin client**: A Supabase service-role client is used for the matching query to read all users' availability across RLS boundaries.

---

### Challenges Faced & Solutions

| Challenge | Problem | Solution |
|-----------|---------|----------|
| **City matching** | Users entered multiple cities in one field (e.g., "Colombo, Gampaha, Malabe") but sessions have a single city. Exact match found nothing. | Switched to wildcard pattern matching (`ilike '%Malabe%'`) so a session in "Malabe" matches availability containing "Malabe" anywhere. |
| **React email rendering** | Resend's `react:` option requires `@react-email/render` to render components to HTML. Failed in Next.js server environment even after installing the package. | Switched to plain `html:` template strings — simpler, no extra dependencies, works reliably. |
| **Resend free tier** | Free tier only sends from `onboarding@resend.dev` and only to the signup email. Multi-account testing was difficult. | Tested with the Resend signup email as the availability-setter. For production, a verified custom domain is needed. |
| **Creator exclusion** | Session creators shouldn't get notified about their own sessions. | Added `.neq("user_id", session.creator_id)` filter to the matching query. |
| **Duplicate emails** | Same user could be notified multiple times for the same session. | `notification_log` table with `UNIQUE(user_id, session_id, type)` constraint prevents duplicates. |

---

### Files Changed

**New files (10):**
- `src/lib/supabase/admin.ts` — Service-role Supabase client
- `src/lib/email/resend.ts` — Resend client
- `src/lib/email/templates/session-match.tsx` — Email template (unused, switched to inline HTML)
- `src/lib/actions/availability.ts` — CRUD server actions for availability
- `src/lib/actions/notifications.ts` — Matching engine + email dispatch
- `src/components/availability/specific-availability-form.tsx`
- `src/components/availability/recurring-availability-form.tsx`
- `src/components/availability/availability-list.tsx`
- `src/components/availability/notification-toggle.tsx`
- `src/app/(protected)/availability/page.tsx`

**Modified files (3):**
- `src/lib/actions/sessions.ts` — Added notification hook in `createSession()`
- `src/components/layout/navbar.tsx` — Added "Availability" nav link
- `src/lib/types/database.ts` — Added availability type interfaces

**New dependencies:**
- `resend` — Email API
- `@react-email/components` — Installed but unused (switched to plain HTML)
- `@radix-ui/react-switch` — shadcn Switch component

---

### Environment Variables Required
- `RESEND_API_KEY` — Resend API key
- `SUPABASE_SERVICE_ROLE_KEY` — Supabase service role key
- `NEXT_PUBLIC_APP_URL` — Deployed app URL for email links

### Database Migration
SQL migration must be run in Supabase SQL Editor to create the 3 new tables, add the `email_notifications` column, and set up RLS policies.
