### PR TITLE
fix Full badge to also check participant count

### DIFF
--- a/src/components/sessions/session-card.tsx
+++ b/src/components/sessions/session-card.tsx
@@ -41,6 +41,7 @@ function getTimingBadge(date: string, time: string) {
 export function SessionCard({ session }: SessionCardProps) {
   const participantCount = session.session_participants?.[0]?.count ?? 0;
   const timing = getTimingBadge(session.date, session.time);
+  const isFull = session.status === "full" || participantCount >= session.max_players;
 
   return (
     <Link href={`/sessions/${session.id}`}>
@@ -52,7 +53,7 @@ export function SessionCard({ session }: SessionCardProps) {
             {timing && (
               <Badge variant={timing.variant}>{timing.label}</Badge>
             )}
-            {session.status === "full" && (
+            {isFull && session.status !== "completed" && session.status !== "cancelled" && (
               <Badge variant="destructive">Full</Badge>
             )}
             {session.status === "completed" && (


### PR DESCRIPTION
The status field might not be updated to "full" in all cases, so also check if participantCount >= max_players.