### PR TITLE
Add Edit session feature

### DIFF
--- a/src/app/(protected)/sessions/[id]/edit/page.tsx
+++ b/src/app/(protected)/sessions/[id]/edit/page.tsx
@@ -1,0 +1,55 @@
+import { notFound, redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { SessionForm } from "@/components/sessions/session-form";
+import type { SessionFormData } from "@/lib/types/database";
+
+export default async function EditSessionPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/login");
+
+  const { data: session } = await supabase
+    .from("sessions")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  if (!session) notFound();
+
+  // Only the creator can edit
+  if (session.creator_id !== user.id) redirect(`/sessions/${id}`);
+
+  // Cannot edit cancelled or completed sessions
+  if (session.status === "cancelled" || session.status === "completed") {
+    redirect(`/sessions/${id}`);
+  }
+
+  const initialData: SessionFormData = {
+    id: session.id,
+    title: session.title,
+    description: session.description,
+    date: session.date,
+    time: session.time,
+    location: session.location,
+    city: session.city,
+    skill_level: session.skill_level,
+    game_type: session.game_type,
+    max_players: session.max_players,
+  };
+
+  return (
+    <div className="container max-w-2xl mx-auto py-8 px-4">
+      <h1 className="text-3xl font-bold mb-6">Edit Session</h1>
+      <SessionForm mode="edit" initialData={initialData} />
+    </div>
+  );
+}

--- a/src/app/(protected)/sessions/[id]/page.tsx
+++ b/src/app/(protected)/sessions/[id]/page.tsx
@@ -7,6 +7,8 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { JoinLeaveButton } from "@/components/sessions/join-leave-button";
 import { ParticipantList } from "@/components/sessions/participant-list";
 import { CancelSessionButton } from "@/components/sessions/cancel-session-button";
+import { EditSessionButton } from "@/components/sessions/edit-session-button";
+import { ConfirmationBanner } from "@/components/sessions/confirmation-banner";
 import { SessionChat } from "@/components/sessions/session-chat";
 import { Calendar, Clock, MapPin, Users } from "lucide-react";
 import { format, differenceInCalendarDays } from "date-fns";
@@ -32,6 +34,8 @@ export default async function SessionDetailPage({
       session_participants(
         user_id,
         joined_at,
+        confirmed,
+        confirmation_deadline,
         profiles(id, full_name, avatar_url, skill_level)
       )
     `
@@ -43,10 +47,24 @@ export default async function SessionDetailPage({
 
   const participantCount = session.session_participants?.length ?? 0;
   const isCreator = user?.id === session.creator_id;
-  const isJoined = session.session_participants?.some(
+  const currentParticipant = session.session_participants?.find(
     (p: { user_id: string }) => p.user_id === user?.id
   );
+  const isJoined = !!currentParticipant;
   const isFull = participantCount >= session.max_players;
+
+  // Check if current user needs to confirm
+  const needsConfirmation =
+    currentParticipant &&
+    !isCreator &&
+    currentParticipant.confirmed === false &&
+    currentParticipant.confirmation_deadline;
+
+  // Check if any participant is unconfirmed (for creator view)
+  const hasAnyUnconfirmed = session.session_participants?.some(
+    (p: { user_id: string; confirmed: boolean }) =>
+      p.user_id !== session.creator_id && p.confirmed === false
+  );
 
   const creatorName = session.creator?.full_name ?? "Unknown";
   const creatorInitials = creatorName
@@ -95,6 +113,14 @@ export default async function SessionDetailPage({
             <p className="text-muted-foreground mt-2">{session.description}</p>
           )}
         </div>
+
+        {/* Confirmation Banner */}
+        {needsConfirmation && session.status !== "cancelled" && session.status !== "completed" && (
+          <ConfirmationBanner
+            sessionId={session.id}
+            confirmationDeadline={currentParticipant.confirmation_deadline}
+          />
+        )}
 
         {/* Details Card */}
         <Card>
@@ -164,7 +190,10 @@ export default async function SessionDetailPage({
                   isFull={isFull}
                 />
                 {isCreator && (
-                  <CancelSessionButton sessionId={session.id} />
+                  <>
+                    <EditSessionButton sessionId={session.id} />
+                    <CancelSessionButton sessionId={session.id} />
+                  </>
                 )}
               </div>
             )}
@@ -185,6 +214,7 @@ export default async function SessionDetailPage({
                 participants={session.session_participants}
                 creatorId={session.creator_id}
                 currentUserId={user?.id}
+                showConfirmationStatus={isCreator && hasAnyUnconfirmed}
               />
             ) : (
               <p className="text-sm text-muted-foreground">

--- a/src/app/(protected)/sessions/page.tsx
+++ b/src/app/(protected)/sessions/page.tsx
@@ -1,5 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
-import { cleanupExpiredSessions } from "@/lib/actions/sessions";
+import { cleanupExpiredSessions, cleanupUnconfirmedParticipants } from "@/lib/actions/sessions";
 import { SessionCard } from "@/components/sessions/session-card";
 import { SessionFilters } from "@/components/sessions/session-filters";
 import { Button } from "@/components/ui/button";
@@ -19,8 +19,9 @@ export default async function SessionsPage({
 }) {
   const params = await searchParams;
 
-  // Clean up expired sessions before fetching
+  // Clean up expired sessions and unconfirmed participants before fetching
   await cleanupExpiredSessions();
+  await cleanupUnconfirmedParticipants();
 
   const supabase = await createClient();
 

--- a/src/components/sessions/confirmation-banner.tsx
+++ b/src/components/sessions/confirmation-banner.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { confirmSession } from "@/lib/actions/sessions";
+import { Button } from "@/components/ui/button";
+import { AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
+import { formatDistanceToNow } from "date-fns";
+
+interface ConfirmationBannerProps {
+  sessionId: string;
+  confirmationDeadline: string;
+}
+
+export function ConfirmationBanner({
+  sessionId,
+  confirmationDeadline,
+}: ConfirmationBannerProps) {
+  const [loading, setLoading] = useState(false);
+  const [timeLeft, setTimeLeft] = useState("");
+
+  useEffect(() => {
+    const update = () => {
+      const deadline = new Date(confirmationDeadline);
+      if (deadline <= new Date()) {
+        setTimeLeft("expired");
+      } else {
+        setTimeLeft(formatDistanceToNow(deadline, { addSuffix: false }));
+      }
+    };
+
+    update();
+    const interval = setInterval(update, 30000);
+    return () => clearInterval(interval);
+  }, [confirmationDeadline]);
+
+  const handleConfirm = async () => {
+    setLoading(true);
+    try {
+      await confirmSession(sessionId);
+      toast.success("Attendance confirmed!");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to confirm");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="bg-amber-50 border border-amber-300 rounded-lg p-4 flex flex-col sm:flex-row items-start sm:items-center gap-3">
+      <AlertTriangle className="h-5 w-5 text-amber-600 shrink-0 mt-0.5 sm:mt-0" />
+      <div className="flex-1">
+        <p className="text-sm font-medium text-amber-900">
+          This session has been updated
+        </p>
+        <p className="text-sm text-amber-700">
+          {timeLeft === "expired"
+            ? "Your confirmation deadline has passed. Your spot may be released."
+            : `Your spot will be released if you don't confirm within ${timeLeft}.`}
+        </p>
+      </div>
+      <Button
+        onClick={handleConfirm}
+        disabled={loading}
+        size="sm"
+        className="shrink-0"
+      >
+        {loading ? "Confirming..." : "Confirm Attendance"}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/sessions/edit-session-button.tsx
+++ b/src/components/sessions/edit-session-button.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Pencil } from "lucide-react";
+
+export function EditSessionButton({ sessionId }: { sessionId: string }) {
+  return (
+    <Link href={`/sessions/${sessionId}/edit`}>
+      <Button variant="outline">
+        <Pencil className="mr-2 h-4 w-4" />
+        Edit Session
+      </Button>
+    </Link>
+  );
+}

--- a/src/components/sessions/participant-list.tsx
+++ b/src/components/sessions/participant-list.tsx
@@ -6,6 +6,8 @@ import { MessageCircle } from "lucide-react";
 
 interface Participant {
   user_id: string;
+  confirmed?: boolean;
+  confirmation_deadline?: string | null;
   profiles: {
     id: string;
     full_name: string | null;
@@ -18,9 +20,15 @@ interface ParticipantListProps {
   participants: Participant[];
   creatorId: string;
   currentUserId?: string;
+  showConfirmationStatus?: boolean;
 }
 
-export function ParticipantList({ participants, creatorId, currentUserId }: ParticipantListProps) {
+export function ParticipantList({
+  participants,
+  creatorId,
+  currentUserId,
+  showConfirmationStatus,
+}: ParticipantListProps) {
   return (
     <div className="space-y-3">
       {participants.map((p) => {
@@ -30,6 +38,7 @@ export function ParticipantList({ participants, creatorId, currentUserId }: Part
           .map((n) => n[0])
           .join("")
           .toUpperCase();
+        const isHost = p.user_id === creatorId;
 
         return (
           <div key={p.user_id} className="flex items-center justify-between">
@@ -40,7 +49,7 @@ export function ParticipantList({ participants, creatorId, currentUserId }: Part
               </Avatar>
               <div className="flex items-center gap-2">
                 <span className="text-sm font-medium">{name}</span>
-                {p.user_id === creatorId && (
+                {isHost && (
                   <Badge variant="outline" className="text-xs">
                     Host
                   </Badge>
@@ -49,6 +58,17 @@ export function ParticipantList({ participants, creatorId, currentUserId }: Part
                   <Badge variant="secondary" className="text-xs">
                     {p.profiles.skill_level}
                   </Badge>
+                )}
+                {showConfirmationStatus && !isHost && (
+                  p.confirmed === false ? (
+                    <Badge variant="destructive" className="text-xs">
+                      Unconfirmed
+                    </Badge>
+                  ) : (
+                    <Badge className="text-xs bg-green-600 hover:bg-green-700">
+                      Confirmed
+                    </Badge>
+                  )
                 )}
               </div>
             </div>

--- a/src/components/sessions/session-chat.tsx
+++ b/src/components/sessions/session-chat.tsx
@@ -41,6 +41,7 @@ interface Message {
   content: string;
   is_edited?: boolean;
   is_deleted?: boolean;
+  is_system_message?: boolean;
   created_at: string;
   profiles?: {
     full_name: string | null;
@@ -460,6 +461,24 @@ export function SessionChat({ sessionId, currentUserId }: SessionChatProps) {
             </p>
           )}
           {messages.map((msg) => {
+            // System messages render differently
+            if (msg.is_system_message) {
+              return (
+                <div key={msg.id} className="flex justify-center my-2">
+                  <div className="bg-amber-50 border border-amber-200 rounded-lg px-4 py-2 max-w-[85%] text-center">
+                    <p className="text-xs text-amber-800 whitespace-pre-line">
+                      {msg.content}
+                    </p>
+                    <p className="text-[10px] text-amber-600 mt-1">
+                      {formatDistanceToNow(new Date(msg.created_at), {
+                        addSuffix: true,
+                      })}
+                    </p>
+                  </div>
+                </div>
+              );
+            }
+
             const isOwn = msg.user_id === currentUserId;
             const name = msg.profiles?.full_name ?? "Unknown";
             const isEditing = editingId === msg.id;

--- a/src/components/sessions/session-form.tsx
+++ b/src/components/sessions/session-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { createSession } from "@/lib/actions/sessions";
+import { createSession, editSession } from "@/lib/actions/sessions";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -14,31 +14,42 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { SessionFormData } from "@/lib/types/database";
 
-export function SessionForm() {
+interface SessionFormProps {
+  mode?: "create" | "edit";
+  initialData?: SessionFormData;
+}
+
+export function SessionForm({ mode = "create", initialData }: SessionFormProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isEdit = mode === "edit";
 
   const handleSubmit = async (formData: FormData) => {
     setLoading(true);
     setError(null);
     try {
-      await createSession(formData);
+      if (isEdit && initialData) {
+        await editSession(initialData.id, formData);
+      } else {
+        await createSession(formData);
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Something went wrong");
       setLoading(false);
     }
   };
 
-  // Default date to tomorrow
+  // Default date to tomorrow (for create mode)
   const tomorrow = new Date();
   tomorrow.setDate(tomorrow.getDate() + 1);
-  const defaultDate = tomorrow.toISOString().split("T")[0];
+  const defaultDate = initialData?.date ?? tomorrow.toISOString().split("T")[0];
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Session Details</CardTitle>
+        <CardTitle>{isEdit ? "Edit Session" : "Session Details"}</CardTitle>
       </CardHeader>
       <CardContent>
         <form action={handleSubmit} className="space-y-6">
@@ -54,6 +65,7 @@ export function SessionForm() {
               id="title"
               name="title"
               placeholder="e.g., Saturday Morning Doubles"
+              defaultValue={initialData?.title ?? ""}
               required
             />
           </div>
@@ -64,6 +76,7 @@ export function SessionForm() {
               id="description"
               name="description"
               placeholder="Any details about the session..."
+              defaultValue={initialData?.description ?? ""}
               rows={3}
             />
           </div>
@@ -86,7 +99,7 @@ export function SessionForm() {
                 id="time"
                 name="time"
                 type="time"
-                defaultValue="09:00"
+                defaultValue={initialData?.time?.slice(0, 5) ?? "09:00"}
                 required
               />
             </div>
@@ -99,6 +112,7 @@ export function SessionForm() {
                 id="location"
                 name="location"
                 placeholder="e.g., City Sports Complex"
+                defaultValue={initialData?.location ?? ""}
                 required
               />
             </div>
@@ -108,6 +122,7 @@ export function SessionForm() {
                 id="city"
                 name="city"
                 placeholder="e.g., Colombo"
+                defaultValue={initialData?.city ?? ""}
                 required
               />
             </div>
@@ -116,7 +131,7 @@ export function SessionForm() {
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
             <div className="space-y-2">
               <Label htmlFor="skill_level">Skill Level</Label>
-              <Select name="skill_level" defaultValue="Open">
+              <Select name="skill_level" defaultValue={initialData?.skill_level ?? "Open"}>
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
@@ -130,7 +145,7 @@ export function SessionForm() {
             </div>
             <div className="space-y-2">
               <Label htmlFor="game_type">Game Type</Label>
-              <Select name="game_type" defaultValue="Either">
+              <Select name="game_type" defaultValue={initialData?.game_type ?? "Either"}>
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
@@ -149,14 +164,20 @@ export function SessionForm() {
                 type="number"
                 min={2}
                 max={20}
-                defaultValue={4}
+                defaultValue={initialData?.max_players ?? 4}
                 required
               />
             </div>
           </div>
 
           <Button type="submit" className="w-full" disabled={loading}>
-            {loading ? "Creating..." : "Create Session"}
+            {loading
+              ? isEdit
+                ? "Saving..."
+                : "Creating..."
+              : isEdit
+                ? "Save Changes"
+                : "Create Session"}
           </Button>
         </form>
       </CardContent>

--- a/src/lib/actions/notifications.ts
+++ b/src/lib/actions/notifications.ts
@@ -2,6 +2,28 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { resend } from "@/lib/email/resend";
 import { format } from "date-fns";
 
+interface SessionEditData {
+  sessionId: string;
+  title: string;
+  date: string;
+  time: string;
+  location: string;
+  city: string;
+  changes: string[];
+  deadline: string;
+  creatorId: string;
+}
+
+interface SessionCancelData {
+  sessionId: string;
+  title: string;
+  date: string;
+  time: string;
+  location: string;
+  city: string;
+  creatorId: string;
+}
+
 interface SessionData {
   id: string;
   creator_id: string;
@@ -132,5 +154,170 @@ export async function notifyMatchingPlayers(session: SessionData) {
   // Log successful notifications
   if (notificationInserts.length > 0) {
     await admin.from("notification_log").insert(notificationInserts);
+  }
+}
+
+export async function notifySessionEdited(data: SessionEditData) {
+  const admin = createAdminClient();
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+
+  // Get all participants except creator
+  const { data: participants } = await admin
+    .from("session_participants")
+    .select("user_id")
+    .eq("session_id", data.sessionId)
+    .neq("user_id", data.creatorId);
+
+  if (!participants || participants.length === 0) return;
+
+  const participantIds = participants.map((p) => p.user_id);
+
+  // Post system chat message listing changes + deadline
+  const deadlineFormatted = format(
+    new Date(data.deadline),
+    "EEEE, MMMM d 'at' h:mm a"
+  );
+  const changesList = data.changes.map((c) => `• ${c}`).join("\n");
+  const systemContent = `Session updated by the host:\n${changesList}\n\nPlease confirm your attendance by ${deadlineFormatted} or your spot will be released.`;
+
+  await admin.from("session_messages").insert({
+    session_id: data.sessionId,
+    user_id: data.creatorId,
+    content: systemContent,
+    is_system_message: true,
+  });
+
+  // Get all participant profiles (edit/cancel emails are always sent - not optional)
+  const { data: profiles } = await admin
+    .from("profiles")
+    .select("id, full_name")
+    .in("id", participantIds);
+
+  if (!profiles || profiles.length === 0) return;
+
+  // Get emails from auth.users
+  const { data: authData } = await admin.auth.admin.listUsers();
+  const emailMap = new Map<string, string>();
+  authData?.users?.forEach((u) => {
+    if (u.email) emailMap.set(u.id, u.email);
+  });
+
+  const sessionDate = new Date(data.date + "T00:00:00");
+  const formattedDate = format(sessionDate, "EEEE, MMMM d, yyyy");
+  const sessionUrl = `${appUrl}/sessions/${data.sessionId}`;
+  const changesHtml = data.changes
+    .map((c) => `<li style="margin: 4px 0; color: #374151;">${c}</li>`)
+    .join("");
+
+  for (const profile of profiles) {
+    const email = emailMap.get(profile.id);
+    if (!email) continue;
+
+    const playerName = profile.full_name ?? "Player";
+
+    try {
+      await resend.emails.send({
+        from: "ShuttleMates <onboarding@resend.dev>",
+        to: email,
+        subject: `Session updated: ${data.title}`,
+        html: `
+          <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
+            <h2 style="color: #1a1a1a; margin: 0 0 16px 0;">Session Updated</h2>
+            <p style="color: #374151; margin: 0 0 8px 0;">Hi ${playerName},</p>
+            <p style="color: #374151; margin: 0 0 16px 0;">The host has made changes to <strong>${data.title}</strong>:</p>
+            <div style="background: #f4f4f5; border-radius: 8px; padding: 16px; margin: 0 0 16px 0;">
+              <p style="margin: 0 0 8px 0; font-weight: bold; color: #1a1a1a;">What changed:</p>
+              <ul style="margin: 0; padding-left: 16px;">${changesHtml}</ul>
+            </div>
+            <div style="background: #fef3c7; border: 1px solid #f59e0b; border-radius: 8px; padding: 16px; margin: 0 0 20px 0;">
+              <p style="margin: 0; color: #92400e; font-weight: bold;">Action required</p>
+              <p style="margin: 4px 0 0 0; color: #92400e;">Please confirm your attendance by <strong>${deadlineFormatted}</strong> or your spot will be released.</p>
+            </div>
+            <a href="${sessionUrl}" style="display: inline-block; background: #18181b; color: #ffffff; padding: 10px 24px; border-radius: 6px; text-decoration: none; font-weight: bold; font-size: 14px;">Confirm Attendance</a>
+            <p style="color: #9ca3af; font-size: 12px; margin-top: 24px;">You received this because you joined this session on ShuttleMates.</p>
+          </div>
+        `,
+      });
+    } catch (err) {
+      console.error(`Failed to send edit notification to ${profile.id}:`, err);
+    }
+  }
+}
+
+export async function notifySessionCancelled(data: SessionCancelData) {
+  const admin = createAdminClient();
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+
+  // Get all participants except creator
+  const { data: participants } = await admin
+    .from("session_participants")
+    .select("user_id")
+    .eq("session_id", data.sessionId)
+    .neq("user_id", data.creatorId);
+
+  if (!participants || participants.length === 0) return;
+
+  const participantIds = participants.map((p) => p.user_id);
+
+  // Post system chat message
+  await admin.from("session_messages").insert({
+    session_id: data.sessionId,
+    user_id: data.creatorId,
+    content: "Session has been cancelled by the host.",
+    is_system_message: true,
+  });
+
+  // Get all participant profiles (cancel emails are always sent - not optional)
+  const { data: profiles } = await admin
+    .from("profiles")
+    .select("id, full_name")
+    .in("id", participantIds);
+
+  if (!profiles || profiles.length === 0) return;
+
+  // Get emails from auth.users
+  const { data: authData } = await admin.auth.admin.listUsers();
+  const emailMap = new Map<string, string>();
+  authData?.users?.forEach((u) => {
+    if (u.email) emailMap.set(u.id, u.email);
+  });
+
+  const sessionDate = new Date(data.date + "T00:00:00");
+  const formattedDate = format(sessionDate, "EEEE, MMMM d, yyyy");
+  const sessionsUrl = `${appUrl}/sessions`;
+
+  for (const profile of profiles) {
+    const email = emailMap.get(profile.id);
+    if (!email) continue;
+
+    const playerName = profile.full_name ?? "Player";
+
+    try {
+      await resend.emails.send({
+        from: "ShuttleMates <onboarding@resend.dev>",
+        to: email,
+        subject: `Session cancelled: ${data.title}`,
+        html: `
+          <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
+            <h2 style="color: #1a1a1a; margin: 0 0 16px 0;">Session Cancelled</h2>
+            <p style="color: #374151; margin: 0 0 8px 0;">Hi ${playerName},</p>
+            <p style="color: #374151; margin: 0 0 16px 0;">Unfortunately, the following session has been cancelled by the host:</p>
+            <div style="background: #fef2f2; border: 1px solid #ef4444; border-radius: 8px; padding: 16px; margin: 0 0 20px 0;">
+              <h3 style="margin: 0 0 12px 0; color: #991b1b;">${data.title}</h3>
+              <p style="margin: 4px 0; color: #374151; font-size: 14px;">Date: ${formattedDate}</p>
+              <p style="margin: 4px 0; color: #374151; font-size: 14px;">Time: ${data.time.slice(0, 5)}</p>
+              <p style="margin: 4px 0; color: #374151; font-size: 14px;">Location: ${data.location}, ${data.city}</p>
+            </div>
+            <a href="${sessionsUrl}" style="display: inline-block; background: #18181b; color: #ffffff; padding: 10px 24px; border-radius: 6px; text-decoration: none; font-weight: bold; font-size: 14px;">Browse Sessions</a>
+            <p style="color: #9ca3af; font-size: 12px; margin-top: 24px;">You received this because you joined this session on ShuttleMates.</p>
+          </div>
+        `,
+      });
+    } catch (err) {
+      console.error(
+        `Failed to send cancellation notification to ${profile.id}:`,
+        err
+      );
+    }
   }
 }

--- a/src/lib/actions/sessions.ts
+++ b/src/lib/actions/sessions.ts
@@ -182,6 +182,16 @@ export async function cancelSession(sessionId: string) {
 
   if (!user) throw new Error("Not authenticated");
 
+  // Fetch session details and participants before cancelling
+  const { data: session } = await supabase
+    .from("sessions")
+    .select("title, date, time, location, city, creator_id")
+    .eq("id", sessionId)
+    .eq("creator_id", user.id)
+    .single();
+
+  if (!session) throw new Error("Session not found or not authorized");
+
   const { error } = await supabase
     .from("sessions")
     .update({ status: "cancelled" })
@@ -190,7 +200,225 @@ export async function cancelSession(sessionId: string) {
 
   if (error) throw new Error(error.message);
 
+  // Notify participants about cancellation
+  try {
+    const { notifySessionCancelled } = await import(
+      "@/lib/actions/notifications"
+    );
+    await notifySessionCancelled({
+      sessionId,
+      title: session.title,
+      date: session.date,
+      time: session.time,
+      location: session.location,
+      city: session.city,
+      creatorId: user.id,
+    });
+  } catch (err) {
+    console.error("Failed to send cancellation notifications:", err);
+  }
+
   revalidatePath(`/sessions/${sessionId}`);
   revalidatePath("/sessions");
   revalidatePath("/my-sessions");
+}
+
+export async function editSession(sessionId: string, formData: FormData) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) throw new Error("Not authenticated");
+
+  // Fetch current session
+  const { data: session } = await supabase
+    .from("sessions")
+    .select("*, session_participants(count)")
+    .eq("id", sessionId)
+    .eq("creator_id", user.id)
+    .single();
+
+  if (!session) throw new Error("Session not found or not authorized");
+  if (session.status === "cancelled" || session.status === "completed") {
+    throw new Error("Cannot edit a cancelled or completed session");
+  }
+
+  // Parse new values
+  const newData = {
+    title: formData.get("title") as string,
+    description: (formData.get("description") as string) || null,
+    date: formData.get("date") as string,
+    time: formData.get("time") as string,
+    location: formData.get("location") as string,
+    city: formData.get("city") as string,
+    skill_level: formData.get("skill_level") as SkillLevel,
+    game_type: formData.get("game_type") as GameType,
+    max_players: parseInt(formData.get("max_players") as string),
+  };
+
+  // Detect what changed
+  const changes: string[] = [];
+  if (session.title !== newData.title) changes.push(`Title: "${newData.title}"`);
+  if (session.description !== newData.description) changes.push("Description updated");
+  if (session.date !== newData.date) changes.push(`Date: ${newData.date}`);
+  if (session.time !== newData.time) changes.push(`Time: ${newData.time}`);
+  if (session.location !== newData.location) changes.push(`Location: ${newData.location}`);
+  if (session.city !== newData.city) changes.push(`City: ${newData.city}`);
+  if (session.skill_level !== newData.skill_level) changes.push(`Skill Level: ${newData.skill_level}`);
+  if (session.game_type !== newData.game_type) changes.push(`Game Type: ${newData.game_type}`);
+  if (session.max_players !== newData.max_players) changes.push(`Max Players: ${newData.max_players}`);
+
+  if (changes.length === 0) {
+    throw new Error("No changes detected");
+  }
+
+  // Validate max_players >= current participant count
+  const currentCount = session.session_participants?.[0]?.count ?? 0;
+  if (newData.max_players < currentCount) {
+    throw new Error(
+      `Cannot reduce max players below current participant count (${currentCount})`
+    );
+  }
+
+  // Update session
+  const { error } = await supabase
+    .from("sessions")
+    .update({
+      ...newData,
+      last_edited_at: new Date().toISOString(),
+    })
+    .eq("id", sessionId)
+    .eq("creator_id", user.id);
+
+  if (error) throw new Error(error.message);
+
+  // Calculate dynamic confirmation deadline
+  const sessionDateTime = new Date(newData.date + "T" + newData.time);
+  const now = new Date();
+  const hoursUntilSession = (sessionDateTime.getTime() - now.getTime()) / (1000 * 60 * 60);
+
+  let deadlineHours: number;
+  if (hoursUntilSession < 6) {
+    deadlineHours = 2;
+  } else if (hoursUntilSession < 24) {
+    deadlineHours = 6;
+  } else if (hoursUntilSession < 72) {
+    deadlineHours = 24;
+  } else {
+    deadlineHours = 48;
+  }
+
+  let deadline = new Date(now.getTime() + deadlineHours * 60 * 60 * 1000);
+  // Cap: deadline never exceeds session start time
+  if (deadline > sessionDateTime) {
+    deadline = sessionDateTime;
+  }
+
+  // Reset confirmed=false for all participants except creator
+  // Use admin client to bypass RLS for updating other users' rows
+  const { createAdminClient } = await import("@/lib/supabase/admin");
+  const admin = createAdminClient();
+  await admin
+    .from("session_participants")
+    .update({
+      confirmed: false,
+      confirmation_deadline: deadline.toISOString(),
+    })
+    .eq("session_id", sessionId)
+    .neq("user_id", user.id);
+
+  // Send notifications (email + system chat message)
+  try {
+    const { notifySessionEdited } = await import(
+      "@/lib/actions/notifications"
+    );
+    await notifySessionEdited({
+      sessionId,
+      title: newData.title,
+      date: newData.date,
+      time: newData.time,
+      location: newData.location,
+      city: newData.city,
+      changes,
+      deadline: deadline.toISOString(),
+      creatorId: user.id,
+    });
+  } catch (err) {
+    console.error("Failed to send edit notifications:", err);
+  }
+
+  revalidatePath(`/sessions/${sessionId}`);
+  revalidatePath("/sessions");
+  revalidatePath("/my-sessions");
+  redirect(`/sessions/${sessionId}`);
+}
+
+export async function confirmSession(sessionId: string) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) throw new Error("Not authenticated");
+
+  const { error } = await supabase
+    .from("session_participants")
+    .update({
+      confirmed: true,
+      confirmation_deadline: null,
+    })
+    .eq("session_id", sessionId)
+    .eq("user_id", user.id);
+
+  if (error) throw new Error(error.message);
+
+  revalidatePath(`/sessions/${sessionId}`);
+}
+
+export async function cleanupUnconfirmedParticipants() {
+  const { createAdminClient } = await import("@/lib/supabase/admin");
+  const admin = createAdminClient();
+
+  // Find participants with confirmed=false AND deadline passed
+  const { data: expired } = await admin
+    .from("session_participants")
+    .select("id, session_id")
+    .eq("confirmed", false)
+    .lt("confirmation_deadline", new Date().toISOString());
+
+  if (!expired || expired.length === 0) return;
+
+  // Get unique session IDs
+  const sessionIds = [...new Set(expired.map((p) => p.session_id))];
+
+  // Delete expired participants
+  const expiredIds = expired.map((p) => p.id);
+  await admin
+    .from("session_participants")
+    .delete()
+    .in("id", expiredIds);
+
+  // Reopen affected sessions from "full" to "open" if spots freed
+  for (const sid of sessionIds) {
+    const { data: session } = await admin
+      .from("sessions")
+      .select("max_players, status")
+      .eq("id", sid)
+      .single();
+
+    if (session && session.status === "full") {
+      const { count } = await admin
+        .from("session_participants")
+        .select("*", { count: "exact", head: true })
+        .eq("session_id", sid);
+
+      if (count !== null && count < session.max_players) {
+        await admin
+          .from("sessions")
+          .update({ status: "open" })
+          .eq("id", sid);
+      }
+    }
+  }
 }

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -24,6 +24,7 @@ export interface SessionMessage {
   content: string;
   is_edited: boolean;
   is_deleted: boolean;
+  is_system_message: boolean;
   created_at: string;
 }
 
@@ -60,6 +61,7 @@ export interface Session {
   game_type: GameType;
   max_players: number;
   status: SessionStatus;
+  last_edited_at: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -68,7 +70,22 @@ export interface SessionParticipant {
   id: string;
   session_id: string;
   user_id: string;
+  confirmed: boolean;
+  confirmation_deadline: string | null;
   joined_at: string;
+}
+
+export interface SessionFormData {
+  id: string;
+  title: string;
+  description: string | null;
+  date: string;
+  time: string;
+  location: string;
+  city: string;
+  skill_level: SkillLevel;
+  game_type: GameType;
+  max_players: number;
 }
 
 export interface SessionWithCreator extends Session {

--- a/supabase/migrations/004_session_edit.sql
+++ b/supabase/migrations/004_session_edit.sql
@@ -1,0 +1,43 @@
+-- Migration 004: Session Edit Feature
+-- Adds support for editing sessions with participant re-confirmation
+
+-- Add confirmed + confirmation_deadline to session_participants
+ALTER TABLE public.session_participants
+  ADD COLUMN confirmed BOOLEAN DEFAULT TRUE,
+  ADD COLUMN confirmation_deadline TIMESTAMPTZ;
+
+-- Add last_edited_at to sessions
+ALTER TABLE public.sessions
+  ADD COLUMN last_edited_at TIMESTAMPTZ;
+
+-- Add is_system_message to session_messages (for auto chat messages)
+ALTER TABLE public.session_messages
+  ADD COLUMN is_system_message BOOLEAN DEFAULT FALSE;
+
+-- RLS: Participants can update their own participation (confirm attendance)
+CREATE POLICY "Users can update own participation"
+  ON public.session_participants FOR UPDATE TO authenticated
+  USING ((SELECT auth.uid()) = user_id)
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+-- RLS: Session creators can update participant rows (reset confirmation on edit)
+CREATE POLICY "Creators can update session participants"
+  ON public.session_participants FOR UPDATE TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.sessions s
+      WHERE s.id = session_participants.session_id
+      AND s.creator_id = (SELECT auth.uid())
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.sessions s
+      WHERE s.id = session_participants.session_id
+      AND s.creator_id = (SELECT auth.uid())
+    )
+  );
+
+-- Index for cleanup queries (finding unconfirmed participants past deadline)
+CREATE INDEX idx_participants_confirmed
+  ON public.session_participants(confirmed, confirmation_deadline);


### PR DESCRIPTION
## Edit Session Feature with Participant Re-confirmation & Cancel Notifications

### Summary
- Added ability for session creators to edit session details (time, date, location, etc.)
- All joined participants must re-confirm attendance after an edit, with a dynamic deadline
- Unconfirmed participants' spots are automatically released after the deadline
- Cancel notifications: when a host cancels, all participants are notified via email + system chat message

### Motivation

Previously, if a session creator needed to change any detail (time, venue, date), their only option was to cancel the session and create a new one. This caused participants to lose their spots and forced the creator to start from scratch. This feature adds proper editing with a re-confirmation flow so everyone stays informed and can confirm they're still available.

### What Changed

#### Database (`supabase/migrations/004_session_edit.sql`)
- `session_participants` → added `confirmed` (BOOLEAN, default TRUE) and `confirmation_deadline` (TIMESTAMPTZ)
- `sessions` → added `last_edited_at` (TIMESTAMPTZ)
- `session_messages` → added `is_system_message` (BOOLEAN, default FALSE)
- Two new RLS policies for UPDATE on `session_participants` (self-confirm + creator reset)
- Index on `(confirmed, confirmation_deadline)` for cleanup queries

#### Types (`src/lib/types/database.ts`)
- Added `is_system_message` to `SessionMessage`
- Added `last_edited_at` to `Session`
- Added `confirmed` and `confirmation_deadline` to `SessionParticipant`
- New `SessionFormData` interface for the edit form

#### Server Actions (`src/lib/actions/sessions.ts`)
- **`editSession()`** — verifies creator, detects changes, updates session, resets confirmation for all participants, triggers notifications
- **`confirmSession()`** — participant confirms their attendance, clears deadline
- **`cleanupUnconfirmedParticipants()`** — removes expired unconfirmed participants, reopens sessions if spots are freed
- **`cancelSession()`** (updated) — now fetches session details before cancelling and calls `notifySessionCancelled()`

#### Notifications (`src/lib/actions/notifications.ts`)
- **`notifySessionEdited()`** — posts system chat message with change list + deadline, sends HTML email with "Confirm Attendance" CTA
- **`notifySessionCancelled()`** — posts system chat message, sends HTML email with session details and "Browse Sessions" CTA

#### Components
| Component | Type | Purpose |
|-----------|------|---------|
| `session-form.tsx` | Modified | Dual-purpose: supports `mode="edit"` with `initialData` pre-filling |
| `edit-session-button.tsx` | New | Pencil icon link to `/sessions/[id]/edit` |
| `confirmation-banner.tsx` | New | Amber warning banner with countdown timer + "Confirm Attendance" button |
| `participant-list.tsx` | Modified | Shows green "Confirmed" / red "Unconfirmed" badges (creator view) |
| `session-chat.tsx` | Modified | System messages render centered with amber background, no action buttons |
| `cancel-session-button.tsx` | Unchanged | Cancel logic moved to server action |

#### Pages
| Page | Type | Purpose |
|------|------|---------|
| `sessions/[id]/edit/page.tsx` | New | Edit page — fetches session, verifies creator, passes data to `SessionForm` |
| `sessions/[id]/page.tsx` | Modified | Added confirmation banner, edit button, fetches `confirmed`/`confirmation_deadline` |
| `sessions/page.tsx` | Modified | Calls `cleanupUnconfirmedParticipants()` on page load |

### Dynamic Deadline Logic

| Time until session | Confirmation deadline |
|--------------------|----------------------|
| < 6 hours          | 2 hours              |
| < 24 hours         | 6 hours              |
| 1–3 days           | 24 hours             |
| 4+ days            | 48 hours             |

> Deadline is capped at the session start time (never exceeds it).

### Problems Encountered & Solutions

#### 1. RLS silently blocking participant updates

**Problem:** After editing a session, the `confirmed` field wasn't being set to `false` for participants. The system chat message appeared (proving the notification function ran), but the "Unconfirmed" badge never showed up. No errors were thrown.

**Root cause:** The `editSession()` function used the regular Supabase client (which goes through Row Level Security) to update other users' `session_participants` rows. Even though we created an RLS policy for creators to update participants, Supabase silently returns 0 rows on RLS-blocked updates instead of throwing an error.

**Solution:** Switched to the **admin client** (bypasses RLS) for resetting `confirmed=false` on participant rows. The admin client was already being used in the notification functions — this made the approach consistent.

#### 2. Email notifications not sending

**Problem:** Edit and cancel emails were never delivered, even though the system chat messages worked fine.

**Root cause:** Both `notifySessionEdited()` and `notifySessionCancelled()` filtered profiles with `.eq("email_notifications", true)`. The `email_notifications` column is an opt-in toggle on the Availability page — meant for availability matching alerts, not session update notifications. Most participants hadn't enabled it.

**Solution:** Removed the `email_notifications` filter from edit/cancel notification functions. These are **transactional notifications** (you joined a session, something changed) — they should always be sent. The `email_notifications` toggle now only controls the optional availability matching emails, as originally intended.

### Test Plan

- [ ] Run SQL migration in Supabase Dashboard
- [ ] `npx next build` passes with no TypeScript errors
- [ ] **Edit flow:** As creator, edit a session → verify session updates, participants get `confirmed=false`, system message appears in chat, email is sent
- [ ] **Confirm flow:** As participant, visit edited session → amber banner appears → click "Confirm Attendance" → banner disappears, badge turns green
- [ ] **Spot release:** Set short deadline, wait for expiry, load `/sessions` → unconfirmed participant is removed
- [ ] **Cancel flow:** As creator, cancel a session → system message appears in chat, participants receive cancellation email
- [ ] **Edge cases:** Creator can't edit cancelled/completed sessions, non-creators can't access edit page, `max_players` can't go below current participant count
