### PR TITLE
scrolling error fixed

### DIFF
--- a/src/components/sessions/session-chat.tsx
+++ b/src/components/sessions/session-chat.tsx
@@ -68,6 +68,7 @@ export function SessionChat({ sessionId, currentUserId }: SessionChatProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const editInputRef = useRef<HTMLInputElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const prevMessageCountRef = useRef<number>(0);
 
   const fetchMessages = useCallback(async () => {
     const supabase = createClient();
@@ -243,7 +244,11 @@ export function SessionChat({ sessionId, currentUserId }: SessionChatProps) {
   }, [fetchMessages]);
 
   useEffect(() => {
-    scrollToBottom();
+    // Only auto-scroll when new messages arrive, not on initial load
+    if (prevMessageCountRef.current > 0 && messages.length > prevMessageCountRef.current) {
+      scrollToBottom();
+    }
+    prevMessageCountRef.current = messages.length;
   }, [messages]);
 
   useEffect(() => {


### PR DESCRIPTION
The fix is in place. Here's what was happening and what changed:

**Problem:** In [session-chat.tsx:245-247](vscode-webview://1sepcjrmhdp7ke8ff9okg0un2kqfrhvrbc57pha135a39jlon81o/src/components/sessions/session-chat.tsx#L245-L247), scrollToBottom() was called every time messages changed — including the initial fetch when you first open the page. This caused the page to immediately scroll down to the chat, hiding the session details above.

**Fix:** Added a prevMessageCountRef that tracks the previous message count. Now scrollToBottom() only fires when new messages arrive (message count increases after initial load), not on the first render. So when you open a session, you stay at the top and can read all the session info. The chat will still auto-scroll when someone sends a new message.