### PR TITLE
users can view sessions without login in

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9020,7 +9020,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.1.tgz",
       "integrity": "sha512-5kcldIXmaEjZcHR6F28IKGSgpmZHaF1IXLWFTG+Xh3S+Cce4MiakLtWY+PlBU69fLbRa8HlaGIrC/QolUpHkhg==",
-      "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
       }

--- a/src/app/(sessions)/layout.tsx
+++ b/src/app/(sessions)/layout.tsx
@@ -1,0 +1,45 @@
+import { createClient } from "@/lib/supabase/server";
+import { Navbar } from "@/components/layout/navbar";
+
+export default async function SessionsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  let profile = null;
+  let unreadCount = 0;
+
+  if (user) {
+    const [{ data: profileData }, { count }] = await Promise.all([
+      supabase
+        .from("profiles")
+        .select("full_name, avatar_url, profile_complete")
+        .eq("id", user.id)
+        .single(),
+      supabase
+        .from("direct_messages")
+        .select("*", { count: "exact", head: true })
+        .eq("receiver_id", user.id)
+        .eq("read", false),
+    ]);
+    profile = profileData;
+    unreadCount = count ?? 0;
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar
+        userName={profile?.full_name ?? null}
+        avatarUrl={profile?.avatar_url ?? null}
+        unreadMessageCount={unreadCount}
+        isAuthenticated={!!user}
+      />
+      <main className="flex-1">{children}</main>
+    </div>
+  );
+}

--- a/src/app/(sessions)/sessions/[id]/page.tsx
+++ b/src/app/(sessions)/sessions/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
@@ -13,6 +14,8 @@ import { SessionChat } from "@/components/sessions/session-chat";
 import { Calendar, Clock, MapPin, Users } from "lucide-react";
 import { format } from "date-fns";
 import { TimingBadge } from "@/components/sessions/timing-badge";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
 
 export default async function SessionDetailPage({
   params,
@@ -26,7 +29,9 @@ export default async function SessionDetailPage({
     data: { user },
   } = await supabase.auth.getUser();
 
-  const { data: session } = await supabase
+  // Use admin client so session data loads for both authenticated and guest users
+  const adminClient = createAdminClient();
+  const { data: session } = await adminClient
     .from("sessions")
     .select(
       `
@@ -69,7 +74,6 @@ export default async function SessionDetailPage({
 
   // A session is expired if its start time has already passed, regardless of DB status
   const isExpired = new Date(session.date + "T" + session.start_time) < new Date();
-
 
   const creatorName = session.creator?.full_name ?? "Unknown";
   const creatorInitials = creatorName
@@ -172,17 +176,25 @@ export default async function SessionDetailPage({
             {/* Action buttons */}
             {session.status !== "cancelled" && session.status !== "completed" && !isExpired && (
               <div className="flex gap-3">
-                <JoinLeaveButton
-                  sessionId={session.id}
-                  isJoined={isJoined ?? false}
-                  isCreator={isCreator}
-                  isFull={isFull}
-                />
-                {isCreator && (
+                {user ? (
                   <>
-                    <EditSessionButton sessionId={session.id} />
-                    <CancelSessionButton sessionId={session.id} />
+                    <JoinLeaveButton
+                      sessionId={session.id}
+                      isJoined={isJoined ?? false}
+                      isCreator={isCreator}
+                      isFull={isFull}
+                    />
+                    {isCreator && (
+                      <>
+                        <EditSessionButton sessionId={session.id} />
+                        <CancelSessionButton sessionId={session.id} />
+                      </>
+                    )}
                   </>
+                ) : (
+                  <Link href={`/login?redirect=/sessions/${session.id}`}>
+                    <Button>Sign in to join</Button>
+                  </Link>
                 )}
               </div>
             )}

--- a/src/app/(sessions)/sessions/page.tsx
+++ b/src/app/(sessions)/sessions/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
 import { cleanupExpiredSessions, cleanupUnconfirmedParticipants } from "@/lib/actions/sessions";
 import { SessionCard } from "@/components/sessions/session-card";
 import { SessionFilters } from "@/components/sessions/session-filters";
@@ -28,8 +29,14 @@ export default async function SessionsPage({
   }
 
   const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
-  let query = supabase
+  // Use admin client so the query works for both authenticated and guest users
+  // regardless of RLS policies on the sessions table
+  const adminClient = createAdminClient();
+  let query = adminClient
     .from("sessions")
     .select(
       `*, session_participants(count)`
@@ -48,12 +55,18 @@ export default async function SessionsPage({
     <div className="container mx-auto py-6 px-4">
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-3xl font-bold">Find Sessions</h1>
-        <Link href="/sessions/new">
-          <Button>
-            <Plus className="mr-2 h-4 w-4" />
-            Create Session
-          </Button>
-        </Link>
+        {user ? (
+          <Link href="/sessions/new">
+            <Button>
+              <Plus className="mr-2 h-4 w-4" />
+              Create Session
+            </Button>
+          </Link>
+        ) : (
+          <Link href="/signup">
+            <Button variant="outline">Sign up to create</Button>
+          </Link>
+        )}
       </div>
 
       <SessionFilters currentFilters={params} />
@@ -67,9 +80,15 @@ export default async function SessionsPage({
             <p className="text-muted-foreground text-lg mb-4">
               No sessions found
             </p>
-            <Link href="/sessions/new">
-              <Button>Be the first to create one</Button>
-            </Link>
+            {user ? (
+              <Link href="/sessions/new">
+                <Button>Be the first to create one</Button>
+              </Link>
+            ) : (
+              <Link href="/signup">
+                <Button>Sign up to create the first session</Button>
+              </Link>
+            )}
           </div>
         )}
       </div>

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -27,9 +27,10 @@ interface NavbarProps {
   userName: string | null;
   avatarUrl: string | null;
   unreadMessageCount?: number;
+  isAuthenticated?: boolean;
 }
 
-export function Navbar({ userName, avatarUrl, unreadMessageCount = 0 }: NavbarProps) {
+export function Navbar({ userName, avatarUrl, unreadMessageCount = 0, isAuthenticated = true }: NavbarProps) {
   const [open, setOpen] = useState(false);
   const router = useRouter();
   const { setTheme, resolvedTheme } = useTheme();
@@ -66,53 +67,82 @@ export function Navbar({ userName, avatarUrl, unreadMessageCount = 0 }: NavbarPr
 
         {/* Desktop nav */}
         <nav className="hidden md:flex items-center gap-6">
-          {navLinks.map((link) => (
-            <Link
-              key={link.href}
-              href={link.href}
-              className="relative text-sm text-muted-foreground hover:text-foreground transition-colors"
-            >
-              {link.label}
-              {link.href === "/messages" && unreadMessageCount > 0 && (
-                <Badge className="absolute -top-2 -right-5 h-4 min-w-4 flex items-center justify-center text-[10px] px-1">
-                  {unreadMessageCount > 99 ? "99+" : unreadMessageCount}
-                </Badge>
-              )}
-            </Link>
-          ))}
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8"
-            onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
-          >
-            <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-            <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-            <span className="sr-only">Toggle theme</span>
-          </Button>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" className="relative h-8 w-8 rounded-full">
-                <Avatar className="h-8 w-8">
-                  <AvatarImage src={avatarUrl ?? undefined} />
-                  <AvatarFallback className="text-xs">{initials}</AvatarFallback>
-                </Avatar>
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem asChild>
-                <Link href="/profile" className="cursor-pointer">
-                  <User className="mr-2 h-4 w-4" />
-                  Profile
+          {isAuthenticated ? (
+            <>
+              {navLinks.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className="relative text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {link.label}
+                  {link.href === "/messages" && unreadMessageCount > 0 && (
+                    <Badge className="absolute -top-2 -right-5 h-4 min-w-4 flex items-center justify-center text-[10px] px-1">
+                      {unreadMessageCount > 99 ? "99+" : unreadMessageCount}
+                    </Badge>
+                  )}
                 </Link>
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={handleSignOut} className="cursor-pointer">
-                <LogOut className="mr-2 h-4 w-4" />
-                Sign out
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+              ))}
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
+              >
+                <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+                <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+                <span className="sr-only">Toggle theme</span>
+              </Button>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" className="relative h-8 w-8 rounded-full">
+                    <Avatar className="h-8 w-8">
+                      <AvatarImage src={avatarUrl ?? undefined} />
+                      <AvatarFallback className="text-xs">{initials}</AvatarFallback>
+                    </Avatar>
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem asChild>
+                    <Link href="/profile" className="cursor-pointer">
+                      <User className="mr-2 h-4 w-4" />
+                      Profile
+                    </Link>
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={handleSignOut} className="cursor-pointer">
+                    <LogOut className="mr-2 h-4 w-4" />
+                    Sign out
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </>
+          ) : (
+            <>
+              <Link
+                href="/sessions"
+                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+              >
+                Find Sessions
+              </Link>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
+              >
+                <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+                <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+                <span className="sr-only">Toggle theme</span>
+              </Button>
+              <Link href="/login">
+                <Button variant="ghost" size="sm">Sign in</Button>
+              </Link>
+              <Link href="/signup">
+                <Button size="sm">Get Started</Button>
+              </Link>
+            </>
+          )}
         </nav>
 
         {/* Mobile nav */}
@@ -127,50 +157,81 @@ export function Navbar({ userName, avatarUrl, unreadMessageCount = 0 }: NavbarPr
               ShuttleMates
             </SheetTitle>
             <nav className="flex flex-col gap-4">
-              {navLinks.map((link) => (
-                <Link
-                  key={link.href}
-                  href={link.href}
-                  onClick={() => setOpen(false)}
-                  className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
-                >
-                  <link.icon className="h-4 w-4" />
-                  {link.label}
-                  {link.href === "/messages" && unreadMessageCount > 0 && (
-                    <Badge className="h-4 min-w-4 flex items-center justify-center text-[10px] px-1">
-                      {unreadMessageCount > 99 ? "99+" : unreadMessageCount}
-                    </Badge>
-                  )}
-                </Link>
-              ))}
-              <Link
-                href="/profile"
-                onClick={() => setOpen(false)}
-                className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
-              >
-                <User className="h-4 w-4" />
-                Profile
-              </Link>
-              <button
-                onClick={() => {
-                  setTheme(resolvedTheme === "dark" ? "light" : "dark");
-                }}
-                className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground text-left"
-              >
-                <Sun className="h-4 w-4 dark:hidden" />
-                <Moon className="h-4 w-4 hidden dark:block" />
-                {resolvedTheme === "dark" ? "Light Mode" : "Dark Mode"}
-              </button>
-              <button
-                onClick={() => {
-                  setOpen(false);
-                  handleSignOut();
-                }}
-                className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground text-left"
-              >
-                <LogOut className="h-4 w-4" />
-                Sign out
-              </button>
+              {isAuthenticated ? (
+                <>
+                  {navLinks.map((link) => (
+                    <Link
+                      key={link.href}
+                      href={link.href}
+                      onClick={() => setOpen(false)}
+                      className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+                    >
+                      <link.icon className="h-4 w-4" />
+                      {link.label}
+                      {link.href === "/messages" && unreadMessageCount > 0 && (
+                        <Badge className="h-4 min-w-4 flex items-center justify-center text-[10px] px-1">
+                          {unreadMessageCount > 99 ? "99+" : unreadMessageCount}
+                        </Badge>
+                      )}
+                    </Link>
+                  ))}
+                  <Link
+                    href="/profile"
+                    onClick={() => setOpen(false)}
+                    className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+                  >
+                    <User className="h-4 w-4" />
+                    Profile
+                  </Link>
+                  <button
+                    onClick={() => {
+                      setTheme(resolvedTheme === "dark" ? "light" : "dark");
+                    }}
+                    className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground text-left"
+                  >
+                    <Sun className="h-4 w-4 dark:hidden" />
+                    <Moon className="h-4 w-4 hidden dark:block" />
+                    {resolvedTheme === "dark" ? "Light Mode" : "Dark Mode"}
+                  </button>
+                  <button
+                    onClick={() => {
+                      setOpen(false);
+                      handleSignOut();
+                    }}
+                    className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground text-left"
+                  >
+                    <LogOut className="h-4 w-4" />
+                    Sign out
+                  </button>
+                </>
+              ) : (
+                <>
+                  <Link
+                    href="/sessions"
+                    onClick={() => setOpen(false)}
+                    className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+                  >
+                    <Calendar className="h-4 w-4" />
+                    Find Sessions
+                  </Link>
+                  <button
+                    onClick={() => {
+                      setTheme(resolvedTheme === "dark" ? "light" : "dark");
+                    }}
+                    className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground text-left"
+                  >
+                    <Sun className="h-4 w-4 dark:hidden" />
+                    <Moon className="h-4 w-4 hidden dark:block" />
+                    {resolvedTheme === "dark" ? "Light Mode" : "Dark Mode"}
+                  </button>
+                  <Link href="/login" onClick={() => setOpen(false)}>
+                    <Button variant="outline" className="w-full">Sign in</Button>
+                  </Link>
+                  <Link href="/signup" onClick={() => setOpen(false)}>
+                    <Button className="w-full">Get Started</Button>
+                  </Link>
+                </>
+              )}
             </nav>
           </SheetContent>
         </Sheet>

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -29,13 +29,24 @@ export async function updateSession(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser();
 
+  const { pathname } = request.nextUrl;
+
+  // /sessions and /sessions/<uuid> are publicly accessible
+  const isPublicSessionsPath =
+    pathname === "/sessions" ||
+    (pathname.startsWith("/sessions/") &&
+      pathname.split("/").length === 3 &&
+      !pathname.endsWith("/new") &&
+      !pathname.endsWith("/edit"));
+
   // Redirect unauthenticated users away from protected routes
   if (
     !user &&
-    !request.nextUrl.pathname.startsWith("/login") &&
-    !request.nextUrl.pathname.startsWith("/signup") &&
-    !request.nextUrl.pathname.startsWith("/auth") &&
-    request.nextUrl.pathname !== "/"
+    !isPublicSessionsPath &&
+    !pathname.startsWith("/login") &&
+    !pathname.startsWith("/signup") &&
+    !pathname.startsWith("/auth") &&
+    pathname !== "/"
   ) {
     const url = request.nextUrl.clone();
     url.pathname = "/login";


### PR DESCRIPTION
**1. Middleware** — Added a path check so /sessions and /sessions/<uuid> skip the login redirect. /sessions/new and /sessions/<uuid>/edit still get blocked.

**2. New (sessions) route group** — Created a new layout that calls getUser() but never redirects. It passes isAuthenticated to the Navbar based on whether a user exists.

**3. Moved session pages out of (protected)/sessions/ into (sessions)/sessions/. The URL stays the same** — Next.js route groups are transparent to URLs. The new/ and edit/ pages stayed in (protected) so they remain auth-gated.

**4. Navbar** — Added isAuthenticated prop. When false, the full nav links/profile dropdown are replaced with just "Find Sessions" + Sign in + Get Started buttons, on both desktop and mobile.

**5. Sessions listing page** — Added getUser() call. "Create Session" button conditionally shows only for logged-in users; guests see "Sign up to create".

**6. Session detail page** — Action buttons section now checks user: logged-in users see Join/Leave/Edit/Cancel; guests see "Sign in to join" linking to /login?redirect=/sessions/<id>.

**7. Admin client for data fetching** — Both public pages use createAdminClient() for the Supabase queries to bypass RLS, since the anon role had no SELECT policy on the sessions table.