### PR TITLE
adding private sessions

### DIFF
--- a/src/app/(protected)/groups/[id]/edit/page.tsx
+++ b/src/app/(protected)/groups/[id]/edit/page.tsx
@@ -1,0 +1,51 @@
+import { notFound, redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { GroupForm } from "@/components/groups/group-form";
+
+export default async function EditGroupPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/login");
+
+  const { data: group } = await supabase
+    .from("recurring_groups")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  if (!group) notFound();
+
+  // Only owner/admin can edit
+  const { data: member } = await supabase
+    .from("group_members")
+    .select("role")
+    .eq("group_id", id)
+    .eq("user_id", user.id)
+    .single();
+
+  if (!member || !["owner", "admin"].includes(member.role)) {
+    notFound();
+  }
+
+  return (
+    <div className="container max-w-lg mx-auto py-8 px-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Edit Group</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <GroupForm mode="edit" group={group} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(protected)/groups/[id]/page.tsx
+++ b/src/app/(protected)/groups/[id]/page.tsx
@@ -1,0 +1,197 @@
+import { notFound } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { rollGroupSessions } from "@/lib/actions/groups";
+import { GroupChat } from "@/components/groups/group-chat";
+import { GroupSessionCard } from "@/components/groups/group-session-card";
+import { MemberList } from "@/components/groups/member-list";
+import { InviteLinkPanel } from "@/components/groups/invite-link-panel";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { Calendar, Clock, MapPin, Pencil, Users } from "lucide-react";
+import Link from "next/link";
+import type { GroupMemberRole } from "@/lib/types/database";
+
+const DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+
+export default async function GroupDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return null;
+
+  // Roll sessions in the background (generate next occurrence if needed)
+  try {
+    await rollGroupSessions(id);
+  } catch {
+    // Non-critical — don't block the page
+  }
+
+  const today = new Date().toISOString().split("T")[0];
+
+  // Fetch group with members, upcoming sessions, RSVPs, and active invite
+  const { data: group } = await supabase
+    .from("recurring_groups")
+    .select(
+      `
+      *,
+      group_members(
+        *,
+        profiles(id, full_name, avatar_url, skill_level)
+      ),
+      sessions!group_id(
+        *,
+        group_session_rsvps(*)
+      ),
+      group_invitations(token, expires_at)
+    `
+    )
+    .eq("id", id)
+    .single();
+
+  if (!group) notFound();
+
+  const currentMember = (group.group_members as any[]).find(
+    (m: { user_id: string }) => m.user_id === user.id
+  );
+  const currentUserRole: GroupMemberRole = currentMember?.role ?? "member";
+  const canManage = currentUserRole === "owner" || currentUserRole === "admin";
+
+  // Filter and sort upcoming sessions
+  const upcomingSessions = ((group.sessions as any[]) ?? [])
+    .filter((s: { date: string; status: string }) => s.date >= today && s.status !== "cancelled")
+    .sort((a: { date: string }, b: { date: string }) => a.date.localeCompare(b.date));
+
+  // Active invite link (non-expired)
+  const activeInvite = ((group.group_invitations as any[]) ?? []).find(
+    (inv: { expires_at: string }) => new Date(inv.expires_at) > new Date()
+  );
+
+  const existingLink = activeInvite
+    ? {
+        url: `${process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000"}/join/${activeInvite.token}`,
+        expiresAt: activeInvite.expires_at,
+      }
+    : null;
+
+  return (
+    <div className="container max-w-3xl mx-auto py-6 px-4 flex flex-col gap-6">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2 mb-1 flex-wrap">
+            <Badge variant="secondary">{group.skill_level}</Badge>
+            <Badge variant="outline">{group.game_type}</Badge>
+            {!group.is_active && <Badge variant="destructive">Paused</Badge>}
+          </div>
+          <h1 className="text-2xl font-bold">{group.name}</h1>
+          {group.description && (
+            <p className="text-muted-foreground text-sm mt-1">{group.description}</p>
+          )}
+          <div className="flex flex-wrap gap-3 mt-2 text-sm text-muted-foreground">
+            <span className="flex items-center gap-1">
+              <Calendar className="h-3.5 w-3.5" />
+              Every {DAY_NAMES[group.day_of_week]}
+            </span>
+            <span className="flex items-center gap-1">
+              <Clock className="h-3.5 w-3.5" />
+              {group.start_time.slice(0, 5)}–{group.end_time.slice(0, 5)}
+            </span>
+            <span className="flex items-center gap-1">
+              <MapPin className="h-3.5 w-3.5" />
+              {group.location}, {group.city}
+            </span>
+            <span className="flex items-center gap-1">
+              <Users className="h-3.5 w-3.5" />
+              {(group.group_members as any[]).length} members
+            </span>
+          </div>
+        </div>
+        {canManage && (
+          <Link href={`/groups/${id}/edit`}>
+            <Button variant="outline" size="sm" className="gap-1 shrink-0">
+              <Pencil className="h-3.5 w-3.5" />
+              Edit
+            </Button>
+          </Link>
+        )}
+      </div>
+
+      {/* Main tabs */}
+      <Tabs defaultValue="chat" className="flex-1">
+        <TabsList className="w-full">
+          <TabsTrigger value="chat" className="flex-1">Chat</TabsTrigger>
+          <TabsTrigger value="schedule" className="flex-1">
+            Schedule{upcomingSessions.length > 0 && ` (${upcomingSessions.length})`}
+          </TabsTrigger>
+          <TabsTrigger value="members" className="flex-1">
+            Members ({(group.group_members as any[]).length})
+          </TabsTrigger>
+        </TabsList>
+
+        {/* Chat tab */}
+        <TabsContent value="chat" className="mt-4">
+          <Card className="overflow-hidden">
+            <div className="h-[calc(100vh-20rem)] flex flex-col">
+              <GroupChat groupId={id} currentUserId={user.id} />
+            </div>
+          </Card>
+        </TabsContent>
+
+        {/* Schedule tab */}
+        <TabsContent value="schedule" className="mt-4 space-y-3">
+          {upcomingSessions.length === 0 ? (
+            <p className="text-center text-muted-foreground py-10">
+              No upcoming sessions. They will be generated automatically.
+            </p>
+          ) : (
+            upcomingSessions.map((session: any) => (
+              <GroupSessionCard
+                key={session.id}
+                session={session}
+                groupMembers={group.group_members as any[]}
+                currentUserId={user.id}
+              />
+            ))
+          )}
+        </TabsContent>
+
+        {/* Members tab */}
+        <TabsContent value="members" className="mt-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Members</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <MemberList
+                groupId={id}
+                members={group.group_members as any[]}
+                currentUserId={user.id}
+                currentUserRole={currentUserRole}
+              />
+
+              {canManage && (
+                <>
+                  <Separator />
+                  <div>
+                    <h4 className="text-sm font-medium mb-3">Invite people</h4>
+                    <InviteLinkPanel groupId={id} existingLink={existingLink} />
+                  </div>
+                </>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/app/(protected)/groups/new/page.tsx
+++ b/src/app/(protected)/groups/new/page.tsx
@@ -1,0 +1,20 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { GroupForm } from "@/components/groups/group-form";
+
+export default function NewGroupPage() {
+  return (
+    <div className="container max-w-lg mx-auto py-8 px-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Create a Recurring Group</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Your crew will have a private chat and auto-scheduled weekly sessions.
+          </p>
+        </CardHeader>
+        <CardContent>
+          <GroupForm mode="create" />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(protected)/groups/page.tsx
+++ b/src/app/(protected)/groups/page.tsx
@@ -1,0 +1,81 @@
+import { createClient } from "@/lib/supabase/server";
+import { GroupCard } from "@/components/groups/group-card";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import { Plus, Users } from "lucide-react";
+
+export default async function GroupsPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return null;
+
+  const today = new Date().toISOString().split("T")[0];
+
+  // Fetch user's groups with member count and next session
+  const { data: memberships } = await supabase
+    .from("group_members")
+    .select(
+      `
+      group_id,
+      recurring_groups(
+        *,
+        group_members(count),
+        sessions!group_id(date)
+      )
+    `
+    )
+    .eq("user_id", user.id);
+
+  const groups = memberships
+    ?.map((m) => {
+      const g = m.recurring_groups as any;
+      if (!g) return null;
+      const memberCount = g.group_members?.[0]?.count ?? 0;
+      const futureDates = (g.sessions ?? [])
+        .map((s: { date: string }) => s.date)
+        .filter((d: string) => d >= today)
+        .sort();
+      return {
+        ...g,
+        memberCount,
+        nextSessionDate: futureDates[0] ?? undefined,
+      };
+    })
+    .filter(Boolean) ?? [];
+
+  return (
+    <div className="container mx-auto py-6 px-4">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-3xl font-bold">My Groups</h1>
+        <Link href="/groups/new">
+          <Button>
+            <Plus className="mr-2 h-4 w-4" />
+            Create Group
+          </Button>
+        </Link>
+      </div>
+
+      {groups.length === 0 ? (
+        <div className="text-center py-20">
+          <Users className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+          <p className="text-muted-foreground text-lg mb-2">No groups yet</p>
+          <p className="text-sm text-muted-foreground mb-6">
+            Create a private group for your regular crew, or ask someone to share an invite link.
+          </p>
+          <Link href="/groups/new">
+            <Button>Create your first group</Button>
+          </Link>
+        </div>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {groups.map((group: any) => (
+            <GroupCard key={group.id} group={group} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(sessions)/join/[token]/page.tsx
+++ b/src/app/(sessions)/join/[token]/page.tsx
@@ -1,0 +1,159 @@
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { redirect } from "next/navigation";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Calendar, Clock, MapPin, Users } from "lucide-react";
+import Link from "next/link";
+import { JoinGroupButton } from "@/components/groups/join-group-button";
+
+const DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+
+export default async function JoinGroupPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // Use admin client to read invite regardless of RLS
+  const admin = createAdminClient();
+  const { data: invitation } = await admin
+    .from("group_invitations")
+    .select("group_id, expires_at")
+    .eq("token", token)
+    .single();
+
+  // Invalid token
+  if (!invitation) {
+    return (
+      <div className="container max-w-md mx-auto py-16 px-4 text-center">
+        <Card>
+          <CardContent className="pt-8 pb-6 space-y-4">
+            <p className="text-2xl">🔗</p>
+            <h1 className="text-xl font-bold">Invalid link</h1>
+            <p className="text-muted-foreground text-sm">
+              This invite link is invalid or has already been revoked.
+            </p>
+            <Link href="/sessions">
+              <Button variant="outline">Browse sessions</Button>
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  // Expired token
+  if (new Date(invitation.expires_at) < new Date()) {
+    return (
+      <div className="container max-w-md mx-auto py-16 px-4 text-center">
+        <Card>
+          <CardContent className="pt-8 pb-6 space-y-4">
+            <p className="text-2xl">⏰</p>
+            <h1 className="text-xl font-bold">Link expired</h1>
+            <p className="text-muted-foreground text-sm">
+              This invite link expired. Ask the group admin to generate a new one.
+            </p>
+            <Link href="/sessions">
+              <Button variant="outline">Browse sessions</Button>
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  // Fetch group details (use admin to bypass RLS)
+  const { data: group } = await admin
+    .from("recurring_groups")
+    .select("*, group_members(count)")
+    .eq("id", invitation.group_id)
+    .single();
+
+  if (!group) {
+    return (
+      <div className="container max-w-md mx-auto py-16 px-4 text-center">
+        <p className="text-muted-foreground">Group not found.</p>
+      </div>
+    );
+  }
+
+  const memberCount = (group.group_members as any[])?.[0]?.count ?? 0;
+
+  // If already a member, redirect straight in
+  if (user) {
+    const { data: existing } = await supabase
+      .from("group_members")
+      .select("id")
+      .eq("group_id", group.id)
+      .eq("user_id", user.id)
+      .single();
+
+    if (existing) {
+      redirect(`/groups/${group.id}`);
+    }
+  }
+
+  return (
+    <div className="container max-w-md mx-auto py-16 px-4">
+      <Card>
+        <CardHeader className="text-center">
+          <p className="text-3xl mb-2">🏸</p>
+          <CardTitle>You&apos;re invited to join</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          {/* Group info */}
+          <div className="bg-muted/50 rounded-lg p-4 space-y-2">
+            <h2 className="font-semibold text-lg">{group.name}</h2>
+            {group.description && (
+              <p className="text-sm text-muted-foreground">{group.description}</p>
+            )}
+            <div className="space-y-1.5 text-sm text-muted-foreground pt-1">
+              <div className="flex items-center gap-2">
+                <Calendar className="h-3.5 w-3.5 shrink-0" />
+                <span>Every {DAY_NAMES[group.day_of_week]}</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Clock className="h-3.5 w-3.5 shrink-0" />
+                <span>{group.start_time.slice(0, 5)} – {group.end_time.slice(0, 5)}</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <MapPin className="h-3.5 w-3.5 shrink-0" />
+                <span>{group.location}, {group.city}</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Users className="h-3.5 w-3.5 shrink-0" />
+                <span>{memberCount} member{memberCount !== 1 ? "s" : ""}</span>
+              </div>
+            </div>
+            <div className="flex gap-2 flex-wrap pt-1">
+              <Badge variant="secondary" className="text-xs">{group.skill_level}</Badge>
+              <Badge variant="outline" className="text-xs">{group.game_type}</Badge>
+            </div>
+          </div>
+
+          {/* Join or login */}
+          {user ? (
+            <JoinGroupButton token={token} />
+          ) : (
+            <div className="space-y-3">
+              <Link href={`/login?redirect=/join/${token}`} className="block">
+                <Button className="w-full">Sign in to join</Button>
+              </Link>
+              <Link href={`/signup?redirect=/join/${token}`} className="block">
+                <Button variant="outline" className="w-full">Create an account</Button>
+              </Link>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(sessions)/sessions/[id]/page.tsx
+++ b/src/app/(sessions)/sessions/[id]/page.tsx
@@ -225,9 +225,21 @@ export default async function SessionDetailPage({
           </CardContent>
         </Card>
 
-        {/* Session Chat - only for upcoming sessions */}
-        {(isJoined || isCreator) && user && session.status !== "cancelled" && session.status !== "completed" && !isExpired && (
+        {/* Session Chat - only for public upcoming sessions; group sessions use group chat */}
+        {(isJoined || isCreator) && user && session.status !== "cancelled" && session.status !== "completed" && !isExpired && !session.group_id && (
           <SessionChat sessionId={session.id} currentUserId={user.id} />
+        )}
+        {session.group_id && (isJoined || isCreator) && user && (
+          <Card>
+            <CardContent className="pt-6 flex items-center justify-between">
+              <p className="text-sm text-muted-foreground">
+                Chat for this session lives in your group.
+              </p>
+              <Link href={`/groups/${session.group_id}`}>
+                <Button variant="outline" size="sm">Open Group Chat</Button>
+              </Link>
+            </CardContent>
+          </Card>
         )}
       </div>
     </div>

--- a/src/app/(sessions)/sessions/page.tsx
+++ b/src/app/(sessions)/sessions/page.tsx
@@ -42,6 +42,7 @@ export default async function SessionsPage({
       `*, session_participants(count)`
     )
     .in("status", ["open", "full"])
+    .eq("is_private", false)
     .gte("date", new Date().toISOString().split("T")[0])
     .order("date", { ascending: true });
 

--- a/src/components/groups/group-card.tsx
+++ b/src/components/groups/group-card.tsx
@@ -1,0 +1,69 @@
+import Link from "next/link";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Calendar, Clock, MapPin, Users } from "lucide-react";
+import type { RecurringGroup } from "@/lib/types/database";
+
+const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+interface GroupCardProps {
+  group: RecurringGroup & { memberCount: number; nextSessionDate?: string };
+}
+
+export function GroupCard({ group }: GroupCardProps) {
+  return (
+    <Link href={`/groups/${group.id}`}>
+      <Card className="hover:shadow-md transition-shadow cursor-pointer h-full">
+        <CardContent className="pt-4 space-y-3">
+          <div>
+            <h3 className="font-semibold text-base truncate">{group.name}</h3>
+            {group.description && (
+              <p className="text-xs text-muted-foreground line-clamp-2 mt-0.5">
+                {group.description}
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-1.5 text-sm text-muted-foreground">
+            <div className="flex items-center gap-2">
+              <Calendar className="h-3.5 w-3.5 shrink-0" />
+              <span>Every {DAY_NAMES[group.day_of_week]}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Clock className="h-3.5 w-3.5 shrink-0" />
+              <span>{group.start_time.slice(0, 5)} – {group.end_time.slice(0, 5)}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <MapPin className="h-3.5 w-3.5 shrink-0" />
+              <span className="truncate">{group.location}, {group.city}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Users className="h-3.5 w-3.5 shrink-0" />
+              <span>{group.memberCount} member{group.memberCount !== 1 ? "s" : ""}</span>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 flex-wrap pt-1">
+            <Badge variant="secondary" className="text-xs">{group.skill_level}</Badge>
+            <Badge variant="outline" className="text-xs">{group.game_type}</Badge>
+            {!group.is_active && (
+              <Badge variant="destructive" className="text-xs">Paused</Badge>
+            )}
+          </div>
+
+          {group.nextSessionDate && (
+            <p className="text-xs text-muted-foreground border-t pt-2">
+              Next session:{" "}
+              <span className="font-medium text-foreground">
+                {new Date(group.nextSessionDate + "T00:00:00").toLocaleDateString(undefined, {
+                  month: "short",
+                  day: "numeric",
+                })}
+              </span>
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/src/components/groups/group-chat.tsx
+++ b/src/components/groups/group-chat.tsx
@@ -1,0 +1,580 @@
+"use client";
+
+import { useEffect, useRef, useState, useCallback } from "react";
+import { createClient } from "@/lib/supabase/client";
+import {
+  sendGroupMessage,
+  editGroupMessage,
+  deleteGroupMessage,
+  toggleReaction,
+} from "@/lib/actions/messages";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Send, Pencil, Trash2, Smile, X, Check } from "lucide-react";
+import { toast } from "sonner";
+import { formatDistanceToNow } from "date-fns";
+import dynamic from "next/dynamic";
+
+const EmojiPicker = dynamic(() => import("@emoji-mart/react"), {
+  ssr: false,
+  loading: () => (
+    <div className="w-[352px] h-[435px] bg-popover border rounded-lg flex items-center justify-center">
+      <span className="text-sm text-muted-foreground">Loading...</span>
+    </div>
+  ),
+});
+
+interface Reaction {
+  id: string;
+  user_id: string;
+  emoji: string;
+  group_message_id: string | null;
+  created_at: string;
+}
+
+interface Message {
+  id: string;
+  group_id: string;
+  user_id: string;
+  content: string;
+  is_edited?: boolean;
+  is_deleted?: boolean;
+  is_system_message?: boolean;
+  created_at: string;
+  profiles?: {
+    full_name: string | null;
+    avatar_url: string | null;
+  };
+}
+
+interface GroupChatProps {
+  groupId: string;
+  currentUserId: string;
+}
+
+export function GroupChat({ groupId, currentUserId }: GroupChatProps) {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [newMessage, setNewMessage] = useState("");
+  const [sending, setSending] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editContent, setEditContent] = useState("");
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const [reactions, setReactions] = useState<Record<string, Reaction[]>>({});
+  const [emojiPickerMsgId, setEmojiPickerMsgId] = useState<string | null>(null);
+  const [showInputEmoji, setShowInputEmoji] = useState(false);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const editInputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const prevMessageCountRef = useRef<number>(0);
+
+  const fetchMessages = useCallback(async () => {
+    const supabase = createClient();
+    const { data } = await supabase
+      .from("group_messages")
+      .select("*, profiles(full_name, avatar_url)")
+      .eq("group_id", groupId)
+      .order("created_at", { ascending: true });
+
+    if (data) {
+      setMessages((prev) => {
+        const temps = prev.filter((m) => m.id.startsWith("temp-"));
+        const remainingTemps = temps.filter(
+          (t) => !data.some((d) => d.content === t.content && d.user_id === t.user_id)
+        );
+        return [...data, ...remainingTemps];
+      });
+
+      if (data.length > 0) {
+        const messageIds = data.map((m) => m.id);
+        const { data: reactionsData } = await supabase
+          .from("message_reactions")
+          .select("*")
+          .in("group_message_id", messageIds);
+
+        if (reactionsData) {
+          const grouped: Record<string, Reaction[]> = {};
+          reactionsData.forEach((r: Reaction) => {
+            const key = r.group_message_id!;
+            if (!grouped[key]) grouped[key] = [];
+            grouped[key].push(r);
+          });
+          setReactions(grouped);
+        }
+      }
+    }
+  }, [groupId]);
+
+  const scrollToBottom = () => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  };
+
+  useEffect(() => {
+    fetchMessages();
+  }, [fetchMessages]);
+
+  // Realtime subscription
+  useEffect(() => {
+    const supabase = createClient();
+
+    const channel = supabase
+      .channel(`group-chat-${groupId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "group_messages",
+          filter: `group_id=eq.${groupId}`,
+        },
+        async (payload) => {
+          const { data } = await supabase
+            .from("group_messages")
+            .select("*, profiles(full_name, avatar_url)")
+            .eq("id", payload.new.id)
+            .single();
+
+          if (data) {
+            setMessages((prev) => {
+              if (prev.some((m) => m.id === data.id)) return prev;
+              const tempIndex = prev.findIndex(
+                (m) => m.id.startsWith("temp-") && m.content === data.content
+              );
+              if (tempIndex !== -1) {
+                const updated = [...prev];
+                updated[tempIndex] = data;
+                return updated;
+              }
+              return [...prev, data];
+            });
+          }
+        }
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "group_messages",
+          filter: `group_id=eq.${groupId}`,
+        },
+        async (payload) => {
+          const { data } = await supabase
+            .from("group_messages")
+            .select("*, profiles(full_name, avatar_url)")
+            .eq("id", payload.new.id)
+            .single();
+
+          if (data) {
+            setMessages((prev) => prev.map((m) => (m.id === data.id ? data : m)));
+          }
+        }
+      )
+      .on(
+        "postgres_changes",
+        { event: "INSERT", schema: "public", table: "message_reactions" },
+        (payload) => {
+          const r = payload.new as Reaction;
+          if (r.group_message_id) {
+            setReactions((prev) => {
+              const existing = prev[r.group_message_id!] || [];
+              if (existing.some((e) => e.id === r.id)) return prev;
+              return { ...prev, [r.group_message_id!]: [...existing, r] };
+            });
+          }
+        }
+      )
+      .on(
+        "postgres_changes",
+        { event: "DELETE", schema: "public", table: "message_reactions" },
+        (payload) => {
+          const old = payload.old as { id: string };
+          setReactions((prev) => {
+            const updated = { ...prev };
+            for (const key in updated) {
+              updated[key] = updated[key].filter((r) => r.id !== old.id);
+              if (updated[key].length === 0) delete updated[key];
+            }
+            return updated;
+          });
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [groupId]);
+
+  // Polling fallback
+  useEffect(() => {
+    const pollInterval = setInterval(fetchMessages, 5000);
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") fetchMessages();
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      clearInterval(pollInterval);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [fetchMessages]);
+
+  useEffect(() => {
+    if (prevMessageCountRef.current > 0 && messages.length > prevMessageCountRef.current) {
+      scrollToBottom();
+    }
+    prevMessageCountRef.current = messages.length;
+  }, [messages]);
+
+  useEffect(() => {
+    if (editingId && editInputRef.current) editInputRef.current.focus();
+  }, [editingId]);
+
+  const handleSend = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newMessage.trim() || sending) return;
+
+    const content = newMessage.trim();
+    setNewMessage("");
+    setSending(true);
+
+    const tempId = `temp-${Date.now()}`;
+    const optimisticMsg: Message = {
+      id: tempId,
+      group_id: groupId,
+      user_id: currentUserId,
+      content,
+      created_at: new Date().toISOString(),
+    };
+    setMessages((prev) => [...prev, optimisticMsg]);
+
+    try {
+      await sendGroupMessage(groupId, content);
+      const supabase = createClient();
+      const { data: latest } = await supabase
+        .from("group_messages")
+        .select("*, profiles(full_name, avatar_url)")
+        .eq("group_id", groupId)
+        .eq("user_id", currentUserId)
+        .eq("content", content)
+        .order("created_at", { ascending: false })
+        .limit(1)
+        .single();
+
+      if (latest) {
+        setMessages((prev) => prev.map((m) => (m.id === tempId ? latest : m)));
+      }
+    } catch (err) {
+      setMessages((prev) => prev.filter((m) => m.id !== tempId));
+      setNewMessage(content);
+      toast.error(err instanceof Error ? err.message : "Failed to send message");
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const handleEdit = useCallback(
+    async (messageId: string) => {
+      if (!editContent.trim()) return;
+      try {
+        await editGroupMessage(messageId, editContent.trim());
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === messageId ? { ...m, content: editContent.trim(), is_edited: true } : m
+          )
+        );
+        setEditingId(null);
+        setEditContent("");
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Failed to edit message");
+      }
+    },
+    [editContent]
+  );
+
+  const handleDelete = useCallback(async (messageId: string) => {
+    try {
+      await deleteGroupMessage(messageId);
+      setMessages((prev) =>
+        prev.map((m) => (m.id === messageId ? { ...m, content: "", is_deleted: true } : m))
+      );
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to delete message");
+    }
+  }, []);
+
+  const handleReaction = useCallback(
+    async (messageId: string, emoji: string) => {
+      const tempReaction: Reaction = {
+        id: `temp-${Date.now()}`,
+        user_id: currentUserId,
+        emoji,
+        group_message_id: messageId,
+        created_at: new Date().toISOString(),
+      };
+
+      const existing = reactions[messageId] || [];
+      const userExisting = existing.find(
+        (r) => r.emoji === emoji && r.user_id === currentUserId
+      );
+
+      if (userExisting) {
+        setReactions((prev) => {
+          const updated = (prev[messageId] || []).filter((r) => r.id !== userExisting.id);
+          if (updated.length === 0) {
+            const rest = { ...prev };
+            delete rest[messageId];
+            return rest;
+          }
+          return { ...prev, [messageId]: updated };
+        });
+      } else {
+        setReactions((prev) => ({
+          ...prev,
+          [messageId]: [...(prev[messageId] || []), tempReaction],
+        }));
+      }
+
+      setEmojiPickerMsgId(null);
+
+      try {
+        await toggleReaction("group", messageId, emoji);
+      } catch {
+        fetchMessages();
+      }
+    },
+    [currentUserId, reactions, fetchMessages]
+  );
+
+  const getInitials = (name: string | null) =>
+    name
+      ? name.split(" ").map((n) => n[0]).join("").toUpperCase()
+      : "?";
+
+  const getGroupedReactions = (messageId: string) => {
+    const msgReactions = reactions[messageId] || [];
+    const grouped: Record<string, { emoji: string; count: number; userReacted: boolean }> = {};
+    msgReactions.forEach((r) => {
+      if (!grouped[r.emoji]) grouped[r.emoji] = { emoji: r.emoji, count: 0, userReacted: false };
+      grouped[r.emoji].count++;
+      if (r.user_id === currentUserId) grouped[r.emoji].userReacted = true;
+    });
+    return Object.values(grouped);
+  };
+
+  const isAnyPickerOpen = emojiPickerMsgId !== null || showInputEmoji;
+
+  return (
+    <div className="flex flex-col h-full relative">
+      {/* Dismiss overlay */}
+      {isAnyPickerOpen && (
+        <div
+          className="fixed inset-0 z-40"
+          onClick={() => {
+            setEmojiPickerMsgId(null);
+            setShowInputEmoji(false);
+          }}
+        />
+      )}
+
+      {/* Messages */}
+      <div
+        ref={scrollContainerRef}
+        className="flex-1 overflow-y-auto space-y-3 p-4 min-h-0"
+      >
+        {messages.length === 0 && (
+          <p className="text-sm text-muted-foreground text-center py-8">
+            No messages yet. Say hello to the group!
+          </p>
+        )}
+        {messages.map((msg) => {
+          if (msg.is_system_message) {
+            return (
+              <div key={msg.id} className="flex justify-center my-2">
+                <div className="bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-lg px-4 py-2 max-w-[85%] text-center">
+                  <p className="text-xs text-amber-800 dark:text-amber-200 whitespace-pre-line">
+                    {msg.content}
+                  </p>
+                  <p className="text-[10px] text-amber-600 dark:text-amber-400 mt-1">
+                    {formatDistanceToNow(new Date(msg.created_at), { addSuffix: true })}
+                  </p>
+                </div>
+              </div>
+            );
+          }
+
+          const isOwn = msg.user_id === currentUserId;
+          const name = msg.profiles?.full_name ?? "Unknown";
+          const isEditing = editingId === msg.id;
+          const grouped = getGroupedReactions(msg.id);
+
+          return (
+            <div
+              key={msg.id}
+              className={`flex gap-2 ${isOwn ? "flex-row-reverse" : ""}`}
+              onMouseEnter={() => setHoveredId(msg.id)}
+              onMouseLeave={() => setHoveredId(null)}
+            >
+              {!isOwn && (
+                <Avatar className="h-7 w-7 shrink-0 mt-1">
+                  <AvatarImage src={msg.profiles?.avatar_url ?? undefined} />
+                  <AvatarFallback className="text-[10px]">{getInitials(name)}</AvatarFallback>
+                </Avatar>
+              )}
+              <div className={`max-w-[75%] relative ${isOwn ? "items-end" : "items-start"}`}>
+                {!isOwn && (
+                  <p className="text-xs text-muted-foreground mb-0.5">{name}</p>
+                )}
+
+                {/* Action buttons */}
+                {hoveredId === msg.id && !isEditing && !msg.is_deleted && !msg.id.startsWith("temp-") && (
+                  <div
+                    className={`absolute -top-8 ${isOwn ? "right-0" : "left-0"} flex items-center gap-0.5 bg-background border rounded-md shadow-sm p-0.5 z-10`}
+                  >
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7"
+                      onClick={() => setEmojiPickerMsgId(emojiPickerMsgId === msg.id ? null : msg.id)}
+                    >
+                      <Smile className="h-3.5 w-3.5" />
+                    </Button>
+                    {isOwn && (
+                      <>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7"
+                          onClick={() => { setEditingId(msg.id); setEditContent(msg.content); }}
+                        >
+                          <Pencil className="h-3.5 w-3.5" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7 text-destructive hover:text-destructive"
+                          onClick={() => handleDelete(msg.id)}
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </Button>
+                      </>
+                    )}
+                  </div>
+                )}
+
+                {/* Emoji picker */}
+                {emojiPickerMsgId === msg.id && (
+                  <div className={`absolute bottom-full mb-1 z-50 ${isOwn ? "right-0" : "left-0"}`}>
+                    <EmojiPicker
+                      onEmojiSelect={(emoji: { native: string }) => handleReaction(msg.id, emoji.native)}
+                      theme="auto"
+                      previewPosition="none"
+                      skinTonePosition="none"
+                    />
+                  </div>
+                )}
+
+                {/* Message bubble */}
+                {msg.is_deleted ? (
+                  <div className="rounded-lg px-3 py-1.5 text-sm bg-muted italic text-muted-foreground">
+                    This message was deleted
+                  </div>
+                ) : isEditing ? (
+                  <div className="flex items-center gap-1">
+                    <Input
+                      ref={editInputRef}
+                      value={editContent}
+                      onChange={(e) => setEditContent(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") handleEdit(msg.id);
+                        if (e.key === "Escape") { setEditingId(null); setEditContent(""); }
+                      }}
+                      className="text-sm h-8"
+                    />
+                    <Button size="icon" variant="ghost" className="h-7 w-7 shrink-0" onClick={() => handleEdit(msg.id)}>
+                      <Check className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button size="icon" variant="ghost" className="h-7 w-7 shrink-0" onClick={() => { setEditingId(null); setEditContent(""); }}>
+                      <X className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                ) : (
+                  <div className={`rounded-lg px-3 py-1.5 text-sm ${isOwn ? "bg-primary text-primary-foreground" : "bg-muted"}`}>
+                    {msg.content}
+                  </div>
+                )}
+
+                {/* Reactions */}
+                {grouped.length > 0 && (
+                  <div className={`flex flex-wrap gap-1 mt-1 ${isOwn ? "justify-end" : ""}`}>
+                    {grouped.map((r) => (
+                      <button
+                        key={r.emoji}
+                        onClick={() => handleReaction(msg.id, r.emoji)}
+                        className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-xs border transition-colors ${
+                          r.userReacted ? "bg-primary/10 border-primary/30" : "bg-muted border-transparent hover:border-border"
+                        }`}
+                      >
+                        <span>{r.emoji}</span>
+                        <span className="text-muted-foreground">{r.count}</span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+
+                {/* Timestamp */}
+                {!isEditing && (
+                  <p className="text-[10px] text-muted-foreground mt-0.5">
+                    {formatDistanceToNow(new Date(msg.created_at), { addSuffix: true })}
+                    {msg.is_edited && !msg.is_deleted && <span className="ml-1">(edited)</span>}
+                  </p>
+                )}
+              </div>
+            </div>
+          );
+        })}
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Input */}
+      <div className="p-4 border-t bg-background relative">
+        {showInputEmoji && (
+          <div className="absolute bottom-full mb-2 left-4 z-50">
+            <EmojiPicker
+              onEmojiSelect={(emoji: { native: string }) => {
+                setNewMessage((prev) => prev + emoji.native);
+                setShowInputEmoji(false);
+                inputRef.current?.focus();
+              }}
+              theme="auto"
+              previewPosition="none"
+              skinTonePosition="none"
+            />
+          </div>
+        )}
+        <form onSubmit={handleSend} className="flex gap-2 items-center">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="shrink-0"
+            onClick={() => setShowInputEmoji(!showInputEmoji)}
+          >
+            <Smile className="h-5 w-5" />
+          </Button>
+          <Input
+            ref={inputRef}
+            value={newMessage}
+            onChange={(e) => setNewMessage(e.target.value)}
+            placeholder="Message the group..."
+            disabled={sending}
+          />
+          <Button type="submit" size="icon" disabled={sending || !newMessage.trim()}>
+            <Send className="h-4 w-4" />
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/groups/group-form.tsx
+++ b/src/components/groups/group-form.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "sonner";
+import { createRecurringGroup, updateGroup } from "@/lib/actions/groups";
+import type { RecurringGroup } from "@/lib/types/database";
+
+const DAY_NAMES = [
+  { value: "0", label: "Sunday" },
+  { value: "1", label: "Monday" },
+  { value: "2", label: "Tuesday" },
+  { value: "3", label: "Wednesday" },
+  { value: "4", label: "Thursday" },
+  { value: "5", label: "Friday" },
+  { value: "6", label: "Saturday" },
+];
+
+const SKILL_LEVELS = ["Beginner", "Intermediate", "Advanced", "Open"];
+const GAME_TYPES = ["Singles", "Doubles", "Either"];
+
+interface GroupFormProps {
+  mode: "create" | "edit";
+  group?: RecurringGroup;
+}
+
+export function GroupForm({ mode, group }: GroupFormProps) {
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+    const formData = new FormData(e.currentTarget);
+
+    startTransition(async () => {
+      try {
+        if (mode === "create") {
+          await createRecurringGroup(formData);
+        } else if (group) {
+          const result = await updateGroup(group.id, formData);
+          if (!result.success) {
+            setError(result.error);
+          } else {
+            toast.success("Group updated");
+          }
+        }
+      } catch (err) {
+        // redirect throws internally for create — ignore
+        if (err instanceof Error && err.message !== "NEXT_REDIRECT") {
+          setError(err.message);
+        }
+      }
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {/* Name */}
+      <div className="space-y-1.5">
+        <Label htmlFor="name">Group name</Label>
+        <Input
+          id="name"
+          name="name"
+          placeholder="Tuesday Night Crew"
+          defaultValue={group?.name}
+          required
+        />
+      </div>
+
+      {/* Description */}
+      <div className="space-y-1.5">
+        <Label htmlFor="description">Description (optional)</Label>
+        <Textarea
+          id="description"
+          name="description"
+          placeholder="Our weekly badminton group..."
+          defaultValue={group?.description ?? ""}
+          rows={2}
+        />
+      </div>
+
+      {/* Day + Time row */}
+      <div className="grid grid-cols-3 gap-3">
+        <div className="space-y-1.5">
+          <Label>Day of week</Label>
+          <Select name="day_of_week" defaultValue={group?.day_of_week?.toString() ?? "2"} required>
+            <SelectTrigger>
+              <SelectValue placeholder="Day" />
+            </SelectTrigger>
+            <SelectContent>
+              {DAY_NAMES.map((d) => (
+                <SelectItem key={d.value} value={d.value}>
+                  {d.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="start_time">Start time</Label>
+          <Input
+            id="start_time"
+            name="start_time"
+            type="time"
+            defaultValue={group?.start_time?.slice(0, 5) ?? "19:00"}
+            required
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="end_time">End time</Label>
+          <Input
+            id="end_time"
+            name="end_time"
+            type="time"
+            defaultValue={group?.end_time?.slice(0, 5) ?? "21:00"}
+            required
+          />
+        </div>
+      </div>
+
+      {/* Location + City */}
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <Label htmlFor="location">Location / court</Label>
+          <Input
+            id="location"
+            name="location"
+            placeholder="Sports Complex Hall A"
+            defaultValue={group?.location}
+            required
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="city">City</Label>
+          <Input
+            id="city"
+            name="city"
+            placeholder="Colombo"
+            defaultValue={group?.city}
+            required
+          />
+        </div>
+      </div>
+
+      {/* Skill + Game type + Max players */}
+      <div className="grid grid-cols-3 gap-3">
+        <div className="space-y-1.5">
+          <Label>Skill level</Label>
+          <Select name="skill_level" defaultValue={group?.skill_level ?? "Open"} required>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {SKILL_LEVELS.map((s) => (
+                <SelectItem key={s} value={s}>{s}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-1.5">
+          <Label>Game type</Label>
+          <Select name="game_type" defaultValue={group?.game_type ?? "Either"} required>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {GAME_TYPES.map((g) => (
+                <SelectItem key={g} value={g}>{g}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="max_players">Max players</Label>
+          <Input
+            id="max_players"
+            name="max_players"
+            type="number"
+            min={2}
+            max={20}
+            defaultValue={group?.max_players ?? 4}
+            required
+          />
+        </div>
+      </div>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+
+      <Button type="submit" disabled={isPending} className="w-full">
+        {isPending
+          ? mode === "create" ? "Creating..." : "Saving..."
+          : mode === "create" ? "Create Group" : "Save Changes"}
+      </Button>
+    </form>
+  );
+}

--- a/src/components/groups/group-session-card.tsx
+++ b/src/components/groups/group-session-card.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { format } from "date-fns";
+import { Calendar, Clock, MapPin, Users } from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { toast } from "sonner";
+import { updateGroupRsvp } from "@/lib/actions/groups";
+import type { GroupMember, GroupSessionRsvp, RsvpStatus, Session } from "@/lib/types/database";
+import type { Profile } from "@/lib/types/database";
+
+interface GroupSessionCardProps {
+  session: Session & { group_session_rsvps: GroupSessionRsvp[] };
+  groupMembers: (GroupMember & {
+    profiles: Pick<Profile, "id" | "full_name" | "avatar_url">;
+  })[];
+  currentUserId: string;
+}
+
+const RSVP_OPTIONS: { status: RsvpStatus; label: string; emoji: string }[] = [
+  { status: "yes", label: "Going", emoji: "✅" },
+  { status: "maybe", label: "Maybe", emoji: "❓" },
+  { status: "no", label: "Can't make it", emoji: "❌" },
+];
+
+function getInitials(name: string | null) {
+  return name
+    ? name.split(" ").map((n) => n[0]).join("").toUpperCase()
+    : "?";
+}
+
+export function GroupSessionCard({
+  session,
+  groupMembers,
+  currentUserId,
+}: GroupSessionCardProps) {
+  const [rsvps, setRsvps] = useState<GroupSessionRsvp[]>(session.group_session_rsvps ?? []);
+  const [isPending, startTransition] = useTransition();
+
+  const myRsvp = rsvps.find((r) => r.user_id === currentUserId)?.status ?? "yes";
+
+  const handleRsvp = (status: RsvpStatus) => {
+    // Optimistic update
+    setRsvps((prev) => {
+      const existing = prev.find((r) => r.user_id === currentUserId);
+      if (existing) return prev.map((r) => (r.user_id === currentUserId ? { ...r, status } : r));
+      return [...prev, { id: "temp", session_id: session.id, user_id: currentUserId, status, updated_at: new Date().toISOString() }];
+    });
+
+    startTransition(async () => {
+      try {
+        await updateGroupRsvp(session.id, status);
+      } catch (err) {
+        // Revert
+        setRsvps(session.group_session_rsvps ?? []);
+        toast.error(err instanceof Error ? err.message : "Failed to update RSVP");
+      }
+    });
+  };
+
+  // Group members by RSVP status
+  const byStatus: Record<RsvpStatus, typeof groupMembers> = { yes: [], maybe: [], no: [] };
+  for (const member of groupMembers) {
+    const rsvp = rsvps.find((r) => r.user_id === member.user_id);
+    const status: RsvpStatus = rsvp?.status ?? "yes";
+    byStatus[status].push(member);
+  }
+
+  const sessionDate = new Date(session.date + "T00:00:00");
+  const isToday = new Date().toISOString().split("T")[0] === session.date;
+  const isTomorrow =
+    new Date(Date.now() + 86400000).toISOString().split("T")[0] === session.date;
+
+  return (
+    <Card>
+      <CardContent className="pt-4 space-y-4">
+        {/* Header */}
+        <div className="flex items-start justify-between gap-2">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2 flex-wrap">
+              {isToday && <Badge variant="default">Today</Badge>}
+              {isTomorrow && <Badge variant="secondary">Tomorrow</Badge>}
+            </div>
+            <div className="flex items-center gap-2 text-sm">
+              <Calendar className="h-4 w-4 text-muted-foreground shrink-0" />
+              <span className="font-medium">
+                {format(sessionDate, "EEEE, MMMM d")}
+              </span>
+            </div>
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Clock className="h-4 w-4 shrink-0" />
+              <span>{session.start_time.slice(0, 5)} – {session.end_time.slice(0, 5)}</span>
+            </div>
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <MapPin className="h-4 w-4 shrink-0" />
+              <span>{session.location}</span>
+            </div>
+          </div>
+          <div className="flex items-center gap-1 text-sm text-muted-foreground shrink-0">
+            <Users className="h-4 w-4" />
+            <span>{byStatus.yes.length}/{session.max_players}</span>
+          </div>
+        </div>
+
+        {/* RSVP grid */}
+        <div className="grid grid-cols-3 gap-2 text-center text-xs">
+          {RSVP_OPTIONS.map(({ status, label, emoji }) => (
+            <div key={status} className="space-y-1">
+              <p className="text-muted-foreground font-medium">
+                {emoji} {label} ({byStatus[status].length})
+              </p>
+              <div className="flex flex-wrap justify-center gap-0.5 min-h-6">
+                {byStatus[status].map((m) => (
+                  <Avatar key={m.user_id} className="h-6 w-6">
+                    <AvatarImage src={m.profiles.avatar_url ?? undefined} />
+                    <AvatarFallback className="text-[8px]">
+                      {getInitials(m.profiles.full_name)}
+                    </AvatarFallback>
+                  </Avatar>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* My RSVP buttons */}
+        <div className="flex gap-2 pt-1 border-t">
+          <span className="text-xs text-muted-foreground self-center mr-1">You:</span>
+          {RSVP_OPTIONS.map(({ status, label }) => (
+            <Button
+              key={status}
+              size="sm"
+              variant={myRsvp === status ? "default" : "outline"}
+              className="flex-1 text-xs h-7"
+              disabled={isPending}
+              onClick={() => handleRsvp(status)}
+            >
+              {label}
+            </Button>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/groups/invite-link-panel.tsx
+++ b/src/components/groups/invite-link-panel.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Copy, Link, RefreshCw, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import { generateInviteLink, revokeInviteLink } from "@/lib/actions/groups";
+import { formatDistanceToNow } from "date-fns";
+
+interface InviteLinkPanelProps {
+  groupId: string;
+  existingLink?: { url: string; expiresAt: string } | null;
+}
+
+export function InviteLinkPanel({ groupId, existingLink }: InviteLinkPanelProps) {
+  const [link, setLink] = useState<{ url: string; expiresAt: string } | null>(
+    existingLink ?? null
+  );
+  const [isPending, startTransition] = useTransition();
+
+  const handleGenerate = () => {
+    startTransition(async () => {
+      try {
+        const result = await generateInviteLink(groupId);
+        setLink(result);
+        toast.success("Invite link generated");
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Failed to generate link");
+      }
+    });
+  };
+
+  const handleRevoke = () => {
+    startTransition(async () => {
+      try {
+        await revokeInviteLink(groupId);
+        setLink(null);
+        toast.success("Invite link revoked");
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Failed to revoke link");
+      }
+    });
+  };
+
+  const handleCopy = () => {
+    if (!link) return;
+    navigator.clipboard.writeText(link.url);
+    toast.success("Copied to clipboard");
+  };
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-muted-foreground">
+        Share an invite link so people can join your group. Links expire after 24 hours.
+      </p>
+
+      {link ? (
+        <div className="space-y-2">
+          <div className="flex gap-2">
+            <Input value={link.url} readOnly className="text-xs font-mono" />
+            <Button size="icon" variant="outline" onClick={handleCopy} title="Copy link">
+              <Copy className="h-4 w-4" />
+            </Button>
+          </div>
+          <div className="flex items-center justify-between">
+            <Label className="text-xs text-muted-foreground">
+              Expires {formatDistanceToNow(new Date(link.expiresAt), { addSuffix: true })}
+            </Label>
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={isPending}
+                onClick={handleGenerate}
+                className="text-xs h-7 gap-1"
+              >
+                <RefreshCw className="h-3 w-3" />
+                New link
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                disabled={isPending}
+                onClick={handleRevoke}
+                className="text-xs h-7 gap-1 text-destructive hover:text-destructive"
+              >
+                <Trash2 className="h-3 w-3" />
+                Revoke
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <Button
+          onClick={handleGenerate}
+          disabled={isPending}
+          variant="outline"
+          className="w-full gap-2"
+        >
+          <Link className="h-4 w-4" />
+          Generate Invite Link
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/groups/join-group-button.tsx
+++ b/src/components/groups/join-group-button.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useTransition, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { acceptInvite } from "@/lib/actions/groups";
+import { toast } from "sonner";
+
+export function JoinGroupButton({ token }: { token: string }) {
+  const [isPending, startTransition] = useTransition();
+  const [joined, setJoined] = useState(false);
+
+  const handleJoin = () => {
+    startTransition(async () => {
+      try {
+        await acceptInvite(token);
+        setJoined(true);
+      } catch (err) {
+        if (err instanceof Error && err.message !== "NEXT_REDIRECT") {
+          toast.error(err.message);
+        }
+      }
+    });
+  };
+
+  return (
+    <Button className="w-full" disabled={isPending || joined} onClick={handleJoin}>
+      {isPending ? "Joining..." : joined ? "Joined!" : "Join Group"}
+    </Button>
+  );
+}

--- a/src/components/groups/member-list.tsx
+++ b/src/components/groups/member-list.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { UserMinus, Shield } from "lucide-react";
+import { toast } from "sonner";
+import { removeMember, promoteMember } from "@/lib/actions/groups";
+import type { GroupMember, GroupMemberRole, Profile } from "@/lib/types/database";
+
+interface MemberListProps {
+  groupId: string;
+  members: (GroupMember & {
+    profiles: Pick<Profile, "id" | "full_name" | "avatar_url" | "skill_level">;
+  })[];
+  currentUserId: string;
+  currentUserRole: GroupMemberRole;
+}
+
+const ROLE_BADGE: Record<GroupMemberRole, { label: string; variant: "default" | "secondary" | "outline" }> = {
+  owner: { label: "Owner", variant: "default" },
+  admin: { label: "Admin", variant: "secondary" },
+  member: { label: "Member", variant: "outline" },
+};
+
+function getInitials(name: string | null) {
+  return name ? name.split(" ").map((n) => n[0]).join("").toUpperCase() : "?";
+}
+
+export function MemberList({ groupId, members, currentUserId, currentUserRole }: MemberListProps) {
+  const [localMembers, setLocalMembers] = useState(members);
+  const [isPending, startTransition] = useTransition();
+
+  const canManage = currentUserRole === "owner" || currentUserRole === "admin";
+
+  const handleRemove = (userId: string) => {
+    startTransition(async () => {
+      try {
+        await removeMember(groupId, userId);
+        setLocalMembers((prev) => prev.filter((m) => m.user_id !== userId));
+        toast.success("Member removed");
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Failed to remove member");
+      }
+    });
+  };
+
+  const handlePromote = (userId: string) => {
+    startTransition(async () => {
+      try {
+        await promoteMember(groupId, userId);
+        setLocalMembers((prev) =>
+          prev.map((m) => (m.user_id === userId ? { ...m, role: "admin" as GroupMemberRole } : m))
+        );
+        toast.success("Member promoted to admin");
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Failed to promote member");
+      }
+    });
+  };
+
+  return (
+    <div className="space-y-3">
+      {localMembers.map((member) => {
+        const roleInfo = ROLE_BADGE[member.role];
+        const isSelf = member.user_id === currentUserId;
+        const isOwner = member.role === "owner";
+
+        return (
+          <div key={member.user_id} className="flex items-center gap-3">
+            <Avatar className="h-9 w-9 shrink-0">
+              <AvatarImage src={member.profiles.avatar_url ?? undefined} />
+              <AvatarFallback className="text-xs">
+                {getInitials(member.profiles.full_name)}
+              </AvatarFallback>
+            </Avatar>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium truncate">
+                  {member.profiles.full_name ?? "Unknown"}
+                  {isSelf && <span className="text-muted-foreground font-normal"> (you)</span>}
+                </span>
+                <Badge variant={roleInfo.variant} className="text-[10px] h-4 px-1.5 shrink-0">
+                  {roleInfo.label}
+                </Badge>
+              </div>
+              {member.profiles.skill_level && (
+                <p className="text-xs text-muted-foreground">{member.profiles.skill_level}</p>
+              )}
+            </div>
+            {canManage && !isOwner && !isSelf && (
+              <div className="flex gap-1 shrink-0">
+                {currentUserRole === "owner" && member.role === "member" && (
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="h-7 w-7"
+                    disabled={isPending}
+                    onClick={() => handlePromote(member.user_id)}
+                    title="Promote to admin"
+                  >
+                    <Shield className="h-3.5 w-3.5" />
+                  </Button>
+                )}
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-7 w-7 text-destructive hover:text-destructive"
+                  disabled={isPending}
+                  onClick={() => handleRemove(member.user_id)}
+                  title="Remove member"
+                >
+                  <UserMinus className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            )}
+            {isSelf && member.role !== "owner" && (
+              <Button
+                size="sm"
+                variant="ghost"
+                className="text-xs text-muted-foreground h-7"
+                disabled={isPending}
+                onClick={() => handleRemove(currentUserId)}
+              >
+                Leave
+              </Button>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -21,7 +21,7 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { Badge } from "@/components/ui/badge";
-import { Menu, LogOut, User, Calendar, Plus, MessageCircle, Clock, Sun, Moon } from "lucide-react";
+import { Menu, LogOut, User, Calendar, Plus, MessageCircle, Clock, Sun, Moon, Users } from "lucide-react";
 
 interface NavbarProps {
   userName: string | null;
@@ -54,6 +54,7 @@ export function Navbar({ userName, avatarUrl, unreadMessageCount = 0, isAuthenti
     { href: "/sessions", label: "Find Sessions", icon: Calendar },
     { href: "/sessions/new", label: "Create Session", icon: Plus },
     { href: "/my-sessions", label: "My Sessions", icon: Calendar },
+    { href: "/groups", label: "My Groups", icon: Users },
     { href: "/availability", label: "Availability", icon: Clock },
     { href: "/messages", label: "Messages", icon: MessageCircle },
   ];

--- a/src/lib/actions/groups.ts
+++ b/src/lib/actions/groups.ts
@@ -1,0 +1,672 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { after } from "next/server";
+import { format } from "date-fns";
+import type { GameType, RsvpStatus, SkillLevel } from "@/lib/types/database";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Returns the next `count` future dates that fall on `dayOfWeek` (0=Sun, 6=Sat),
+ *  starting strictly after `afterDate` (defaults to today). */
+function getNextOccurrences(
+  dayOfWeek: number,
+  count: number,
+  afterDate?: Date
+): Date[] {
+  const dates: Date[] = [];
+  const cursor = afterDate ? new Date(afterDate) : new Date();
+  cursor.setHours(0, 0, 0, 0);
+
+  while (dates.length < count) {
+    cursor.setDate(cursor.getDate() + 1);
+    if (cursor.getDay() === dayOfWeek) {
+      dates.push(new Date(cursor));
+    }
+  }
+  return dates;
+}
+
+// ─── Create group ────────────────────────────────────────────────────────────
+
+export async function createRecurringGroup(formData: FormData) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) throw new Error("Not authenticated");
+
+  const groupData = {
+    owner_id: user.id,
+    name: formData.get("name") as string,
+    description: (formData.get("description") as string) || null,
+    day_of_week: parseInt(formData.get("day_of_week") as string),
+    start_time: formData.get("start_time") as string,
+    end_time: formData.get("end_time") as string,
+    location: formData.get("location") as string,
+    city: formData.get("city") as string,
+    skill_level: formData.get("skill_level") as SkillLevel,
+    game_type: formData.get("game_type") as GameType,
+    max_players: parseInt(formData.get("max_players") as string),
+  };
+
+  const admin = createAdminClient();
+
+  const { data: group, error } = await admin
+    .from("recurring_groups")
+    .insert(groupData)
+    .select()
+    .single();
+
+  if (error) throw new Error(error.message);
+
+  // Add owner as first member with 'owner' role (must happen before SELECT policy can read group)
+  await admin.from("group_members").insert({
+    group_id: group.id,
+    user_id: user.id,
+    role: "owner",
+  });
+
+  // Generate initial sessions and notify in background
+  after(async () => {
+    try {
+      await generateGroupSessions(group.id, group, 4);
+
+      // Post welcome system message
+      const admin = createAdminClient();
+      const dayNames = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+      await admin.from("group_messages").insert({
+        group_id: group.id,
+        user_id: user.id,
+        content: `Welcome to ${group.name}! This is your group's chat. Sessions are scheduled every ${dayNames[group.day_of_week]} at ${group.start_time.slice(0, 5)}–${group.end_time.slice(0, 5)}.`,
+        is_system_message: true,
+      });
+    } catch (err) {
+      console.error("Failed to generate initial group sessions:", err);
+    }
+  });
+
+  revalidatePath("/groups");
+  redirect(`/groups/${group.id}`);
+}
+
+// ─── Generate sessions ───────────────────────────────────────────────────────
+
+/** Generate `count` new occurrences for the group. Used on creation and rolling. */
+export async function generateGroupSessions(
+  groupId: string,
+  group: {
+    day_of_week: number;
+    start_time: string;
+    end_time: string;
+    location: string;
+    city: string;
+    skill_level: string;
+    game_type: string;
+    max_players: number;
+    owner_id: string;
+    name: string;
+  },
+  count: number
+) {
+  const admin = createAdminClient();
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+
+  // Find the latest scheduled future session for this group
+  const today = new Date().toISOString().split("T")[0];
+  const { data: existingSessions } = await admin
+    .from("sessions")
+    .select("date")
+    .eq("group_id", groupId)
+    .gte("date", today)
+    .order("date", { ascending: false })
+    .limit(1);
+
+  const latestDate =
+    existingSessions && existingSessions.length > 0
+      ? new Date(existingSessions[0].date + "T00:00:00")
+      : undefined;
+
+  const newDates = getNextOccurrences(group.day_of_week, count, latestDate);
+
+  // Get current group members for bulk participant + RSVP inserts
+  const { data: members } = await admin
+    .from("group_members")
+    .select("user_id")
+    .eq("group_id", groupId);
+
+  const memberIds = members?.map((m) => m.user_id) ?? [];
+
+  for (const date of newDates) {
+    const dateStr = date.toISOString().split("T")[0];
+
+    // Insert the session
+    const { data: session, error: sessionError } = await admin
+      .from("sessions")
+      .insert({
+        creator_id: group.owner_id,
+        title: group.name,
+        date: dateStr,
+        start_time: group.start_time,
+        end_time: group.end_time,
+        location: group.location,
+        city: group.city,
+        skill_level: group.skill_level,
+        game_type: group.game_type,
+        max_players: group.max_players,
+        group_id: groupId,
+        is_private: true,
+        status: "open",
+      })
+      .select("id")
+      .single();
+
+    if (sessionError || !session) {
+      console.error("Failed to insert session for date", dateStr, sessionError);
+      continue;
+    }
+
+    if (memberIds.length > 0) {
+      // Bulk insert session_participants
+      await admin.from("session_participants").insert(
+        memberIds.map((uid) => ({ session_id: session.id, user_id: uid }))
+      );
+
+      // Bulk insert default yes RSVPs
+      await admin.from("group_session_rsvps").insert(
+        memberIds.map((uid) => ({
+          session_id: session.id,
+          user_id: uid,
+          status: "yes",
+        }))
+      );
+    }
+
+    // Post system message in group chat for the new session
+    const dayNames = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+    const formattedDate = format(date, "MMMM d, yyyy");
+    await admin.from("group_messages").insert({
+      group_id: groupId,
+      user_id: group.owner_id,
+      content: `📅 Next session: ${dayNames[group.day_of_week]} ${formattedDate}, ${group.start_time.slice(0, 5)}–${group.end_time.slice(0, 5)} at ${group.location}. Update your RSVP in the Schedule tab.`,
+      is_system_message: true,
+    });
+
+    // Send email to members with notifications enabled
+    if (memberIds.length > 0) {
+      const { data: profiles } = await admin
+        .from("profiles")
+        .select("id, full_name, email_notifications")
+        .in("id", memberIds)
+        .eq("email_notifications", true);
+
+      if (profiles && profiles.length > 0) {
+        const { data: authData } = await admin.auth.admin.listUsers();
+        const emailMap = new Map<string, string>();
+        authData?.users?.forEach((u) => {
+          if (u.email) emailMap.set(u.id, u.email);
+        });
+
+        const { sendEmail } = await import("@/lib/email/smtp");
+        const groupUrl = `${appUrl}/groups/${groupId}`;
+
+        for (const profile of profiles) {
+          const email = emailMap.get(profile.id);
+          if (!email) continue;
+
+          try {
+            await sendEmail({
+              to: email,
+              subject: `${group.name} — session scheduled for ${formattedDate}`,
+              html: `
+                <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
+                  <h2 style="color: #1a1a1a; margin: 0 0 16px 0;">New session scheduled</h2>
+                  <p style="color: #374151; margin: 0 0 8px 0;">Hi ${profile.full_name ?? "Player"},</p>
+                  <p style="color: #374151; margin: 0 0 16px 0;">Your group <strong>${group.name}</strong> has a session coming up:</p>
+                  <div style="background: #f4f4f5; border-radius: 8px; padding: 16px; margin: 0 0 20px 0;">
+                    <p style="margin: 4px 0; color: #374151; font-size: 14px;">📅 ${dayNames[group.day_of_week]}, ${formattedDate}</p>
+                    <p style="margin: 4px 0; color: #374151; font-size: 14px;">🕐 ${group.start_time.slice(0, 5)}–${group.end_time.slice(0, 5)}</p>
+                    <p style="margin: 4px 0; color: #374151; font-size: 14px;">📍 ${group.location}, ${group.city}</p>
+                  </div>
+                  <p style="color: #374151; margin: 0 0 16px 0;">You're marked as <strong>Going</strong> by default. Update your RSVP if your plans change.</p>
+                  <a href="${groupUrl}" style="display: inline-block; background: #18181b; color: #ffffff; padding: 10px 24px; border-radius: 6px; text-decoration: none; font-weight: bold; font-size: 14px;">Update RSVP</a>
+                  <p style="color: #9ca3af; font-size: 12px; margin-top: 24px;">You received this because you are a member of ${group.name} on ShuttleMates.</p>
+                </div>
+              `,
+            });
+          } catch (err) {
+            console.error(`Failed to send session notification to ${profile.id}:`, err);
+          }
+        }
+      }
+    }
+  }
+}
+
+// ─── Rolling session generation ──────────────────────────────────────────────
+
+/** Called on group page load. Generates one more occurrence if the latest is within 7 days. */
+export async function rollGroupSessions(groupId: string) {
+  const admin = createAdminClient();
+  const today = new Date();
+  const todayStr = today.toISOString().split("T")[0];
+
+  const { data: latestSession } = await admin
+    .from("sessions")
+    .select("date")
+    .eq("group_id", groupId)
+    .gte("date", todayStr)
+    .order("date", { ascending: false })
+    .limit(1)
+    .single();
+
+  if (!latestSession) return;
+
+  const latestDate = new Date(latestSession.date + "T00:00:00");
+  const daysUntilLatest = Math.floor(
+    (latestDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24)
+  );
+
+  if (daysUntilLatest > 7) return;
+
+  const { data: group } = await admin
+    .from("recurring_groups")
+    .select("*")
+    .eq("id", groupId)
+    .eq("is_active", true)
+    .single();
+
+  if (!group) return;
+
+  await generateGroupSessions(groupId, group, 1);
+}
+
+// ─── Invite link ─────────────────────────────────────────────────────────────
+
+export async function generateInviteLink(
+  groupId: string
+): Promise<{ url: string; expiresAt: string }> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) throw new Error("Not authenticated");
+
+  // Check caller is owner or admin
+  const { data: member } = await supabase
+    .from("group_members")
+    .select("role")
+    .eq("group_id", groupId)
+    .eq("user_id", user.id)
+    .single();
+
+  if (!member || !["owner", "admin"].includes(member.role)) {
+    throw new Error("Not authorized");
+  }
+
+  // Delete any existing invite for this group
+  await supabase.from("group_invitations").delete().eq("group_id", groupId);
+
+  const token = crypto.randomUUID();
+  const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+
+  const { error } = await supabase.from("group_invitations").insert({
+    group_id: groupId,
+    token,
+    created_by: user.id,
+    expires_at: expiresAt,
+  });
+
+  if (error) throw new Error(error.message);
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+  return { url: `${appUrl}/join/${token}`, expiresAt };
+}
+
+export async function revokeInviteLink(groupId: string) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) throw new Error("Not authenticated");
+
+  const { data: member } = await supabase
+    .from("group_members")
+    .select("role")
+    .eq("group_id", groupId)
+    .eq("user_id", user.id)
+    .single();
+
+  if (!member || !["owner", "admin"].includes(member.role)) {
+    throw new Error("Not authorized");
+  }
+
+  await supabase.from("group_invitations").delete().eq("group_id", groupId);
+  revalidatePath(`/groups/${groupId}`);
+}
+
+// ─── Accept invite ───────────────────────────────────────────────────────────
+
+export async function acceptInvite(token: string) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) throw new Error("Not authenticated");
+
+  // Use admin client to read invite regardless of RLS
+  const admin = createAdminClient();
+  const { data: invitation } = await admin
+    .from("group_invitations")
+    .select("group_id, expires_at")
+    .eq("token", token)
+    .single();
+
+  if (!invitation) throw new Error("Invalid invite link");
+  if (new Date(invitation.expires_at) < new Date()) {
+    throw new Error("This invite link has expired");
+  }
+
+  const groupId = invitation.group_id;
+
+  // Check if already a member
+  const { data: existing } = await supabase
+    .from("group_members")
+    .select("id")
+    .eq("group_id", groupId)
+    .eq("user_id", user.id)
+    .single();
+
+  if (existing) {
+    redirect(`/groups/${groupId}`);
+  }
+
+  // Add to group
+  const { error } = await admin.from("group_members").insert({
+    group_id: groupId,
+    user_id: user.id,
+    role: "member",
+  });
+
+  if (error) throw new Error(error.message);
+
+  // Add to all upcoming sessions of the group + default RSVP
+  const today = new Date().toISOString().split("T")[0];
+  const { data: upcomingSessions } = await admin
+    .from("sessions")
+    .select("id")
+    .eq("group_id", groupId)
+    .gte("date", today)
+    .in("status", ["open", "full"]);
+
+  if (upcomingSessions && upcomingSessions.length > 0) {
+    const sessionIds = upcomingSessions.map((s) => s.id);
+    await admin.from("session_participants").insert(
+      sessionIds.map((sid) => ({ session_id: sid, user_id: user.id }))
+    );
+    await admin.from("group_session_rsvps").insert(
+      sessionIds.map((sid) => ({ session_id: sid, user_id: user.id, status: "yes" }))
+    );
+  }
+
+  // Post system message
+  const { data: profile } = await admin
+    .from("profiles")
+    .select("full_name")
+    .eq("id", user.id)
+    .single();
+
+  const { data: group } = await admin
+    .from("recurring_groups")
+    .select("owner_id")
+    .eq("id", groupId)
+    .single();
+
+  await admin.from("group_messages").insert({
+    group_id: groupId,
+    user_id: group?.owner_id ?? user.id,
+    content: `${profile?.full_name ?? "A new player"} joined the group.`,
+    is_system_message: true,
+  });
+
+  revalidatePath(`/groups/${groupId}`);
+  redirect(`/groups/${groupId}`);
+}
+
+// ─── Remove member ───────────────────────────────────────────────────────────
+
+export async function removeMember(groupId: string, targetUserId: string) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) throw new Error("Not authenticated");
+
+  // Check caller is owner/admin OR removing themselves
+  if (user.id !== targetUserId) {
+    const { data: callerMember } = await supabase
+      .from("group_members")
+      .select("role")
+      .eq("group_id", groupId)
+      .eq("user_id", user.id)
+      .single();
+
+    if (!callerMember || !["owner", "admin"].includes(callerMember.role)) {
+      throw new Error("Not authorized");
+    }
+
+    // Prevent removing the owner
+    const { data: targetMember } = await supabase
+      .from("group_members")
+      .select("role")
+      .eq("group_id", groupId)
+      .eq("user_id", targetUserId)
+      .single();
+
+    if (targetMember?.role === "owner") {
+      throw new Error("Cannot remove the group owner");
+    }
+  }
+
+  const admin = createAdminClient();
+
+  // Get target name for system message
+  const { data: profile } = await admin
+    .from("profiles")
+    .select("full_name")
+    .eq("id", targetUserId)
+    .single();
+
+  // Remove from group
+  await admin
+    .from("group_members")
+    .delete()
+    .eq("group_id", groupId)
+    .eq("user_id", targetUserId);
+
+  // Remove from upcoming sessions
+  const today = new Date().toISOString().split("T")[0];
+  const { data: upcomingSessions } = await admin
+    .from("sessions")
+    .select("id")
+    .eq("group_id", groupId)
+    .gte("date", today);
+
+  if (upcomingSessions && upcomingSessions.length > 0) {
+    const sessionIds = upcomingSessions.map((s) => s.id);
+    await admin
+      .from("session_participants")
+      .delete()
+      .in("session_id", sessionIds)
+      .eq("user_id", targetUserId);
+    await admin
+      .from("group_session_rsvps")
+      .delete()
+      .in("session_id", sessionIds)
+      .eq("user_id", targetUserId);
+  }
+
+  // Get group owner for system message author
+  const { data: group } = await admin
+    .from("recurring_groups")
+    .select("owner_id")
+    .eq("id", groupId)
+    .single();
+
+  const name = profile?.full_name ?? "A member";
+  const isLeaving = user.id === targetUserId;
+  await admin.from("group_messages").insert({
+    group_id: groupId,
+    user_id: group?.owner_id ?? user.id,
+    content: isLeaving ? `${name} left the group.` : `${name} was removed from the group.`,
+    is_system_message: true,
+  });
+
+  revalidatePath(`/groups/${groupId}`);
+  revalidatePath("/groups");
+}
+
+// ─── Update RSVP ─────────────────────────────────────────────────────────────
+
+export async function updateGroupRsvp(sessionId: string, status: RsvpStatus) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) throw new Error("Not authenticated");
+
+  const { error } = await supabase.from("group_session_rsvps").upsert(
+    { session_id: sessionId, user_id: user.id, status },
+    { onConflict: "session_id,user_id" }
+  );
+
+  if (error) throw new Error(error.message);
+
+  // Find group_id to revalidate
+  const { data: session } = await supabase
+    .from("sessions")
+    .select("group_id")
+    .eq("id", sessionId)
+    .single();
+
+  if (session?.group_id) {
+    revalidatePath(`/groups/${session.group_id}`);
+  }
+}
+
+// ─── Update group settings ───────────────────────────────────────────────────
+
+export async function updateGroup(
+  groupId: string,
+  formData: FormData
+): Promise<{ success: true } | { success: false; error: string }> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return { success: false, error: "Not authenticated" };
+
+  const { data: member } = await supabase
+    .from("group_members")
+    .select("role")
+    .eq("group_id", groupId)
+    .eq("user_id", user.id)
+    .single();
+
+  if (!member || !["owner", "admin"].includes(member.role)) {
+    return { success: false, error: "Not authorized" };
+  }
+
+  const { data: current } = await supabase
+    .from("recurring_groups")
+    .select("*")
+    .eq("id", groupId)
+    .single();
+
+  if (!current) return { success: false, error: "Group not found" };
+
+  const newData = {
+    name: formData.get("name") as string,
+    description: (formData.get("description") as string) || null,
+    day_of_week: parseInt(formData.get("day_of_week") as string),
+    start_time: formData.get("start_time") as string,
+    end_time: formData.get("end_time") as string,
+    location: formData.get("location") as string,
+    city: formData.get("city") as string,
+    skill_level: formData.get("skill_level") as SkillLevel,
+    game_type: formData.get("game_type") as GameType,
+    max_players: parseInt(formData.get("max_players") as string),
+  };
+
+  const { error } = await supabase
+    .from("recurring_groups")
+    .update(newData)
+    .eq("id", groupId);
+
+  if (error) return { success: false, error: error.message };
+
+  // Detect schedule changes and post system message
+  const dayNames = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+  const changes: string[] = [];
+  if (current.name !== newData.name) changes.push(`Name: "${newData.name}"`);
+  if (current.day_of_week !== newData.day_of_week) changes.push(`Day: ${dayNames[newData.day_of_week]}`);
+  if (current.start_time.slice(0, 5) !== newData.start_time.slice(0, 5)) changes.push(`Start time: ${newData.start_time}`);
+  if (current.end_time.slice(0, 5) !== newData.end_time.slice(0, 5)) changes.push(`End time: ${newData.end_time}`);
+  if (current.location !== newData.location) changes.push(`Location: ${newData.location}`);
+  if (current.city !== newData.city) changes.push(`City: ${newData.city}`);
+
+  if (changes.length > 0) {
+    after(async () => {
+      const admin = createAdminClient();
+      const changesList = changes.map((c) => `• ${c}`).join("\n");
+      await admin.from("group_messages").insert({
+        group_id: groupId,
+        user_id: user.id,
+        content: `Group settings updated:\n${changesList}`,
+        is_system_message: true,
+      });
+    });
+  }
+
+  revalidatePath(`/groups/${groupId}`);
+  revalidatePath("/groups");
+  return { success: true };
+}
+
+// ─── Promote member to admin ─────────────────────────────────────────────────
+
+export async function promoteMember(groupId: string, targetUserId: string) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) throw new Error("Not authenticated");
+
+  const { data: callerMember } = await supabase
+    .from("group_members")
+    .select("role")
+    .eq("group_id", groupId)
+    .eq("user_id", user.id)
+    .single();
+
+  if (callerMember?.role !== "owner") throw new Error("Only the owner can promote members");
+
+  await supabase
+    .from("group_members")
+    .update({ role: "admin" })
+    .eq("group_id", groupId)
+    .eq("user_id", targetUserId);
+
+  revalidatePath(`/groups/${groupId}`);
+}

--- a/src/lib/actions/messages.ts
+++ b/src/lib/actions/messages.ts
@@ -129,8 +129,67 @@ export async function deleteSessionMessage(messageId: string) {
   if (error) throw new Error(error.message);
 }
 
+export async function sendGroupMessage(groupId: string, content: string) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) throw new Error("Not authenticated");
+
+  const trimmed = content.trim();
+  if (!trimmed) throw new Error("Message cannot be empty");
+
+  const { error } = await supabase.from("group_messages").insert({
+    group_id: groupId,
+    user_id: user.id,
+    content: trimmed,
+  });
+
+  if (error) throw new Error(error.message);
+
+  revalidatePath(`/groups/${groupId}`);
+}
+
+export async function editGroupMessage(messageId: string, newContent: string) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) throw new Error("Not authenticated");
+
+  const trimmed = newContent.trim();
+  if (!trimmed) throw new Error("Message cannot be empty");
+
+  const { error } = await supabase
+    .from("group_messages")
+    .update({ content: trimmed, is_edited: true })
+    .eq("id", messageId)
+    .eq("user_id", user.id);
+
+  if (error) throw new Error(error.message);
+}
+
+export async function deleteGroupMessage(messageId: string) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) throw new Error("Not authenticated");
+
+  const { error } = await supabase
+    .from("group_messages")
+    .update({ content: "", is_deleted: true })
+    .eq("id", messageId)
+    .eq("user_id", user.id);
+
+  if (error) throw new Error(error.message);
+}
+
 export async function toggleReaction(
-  messageType: "direct" | "session",
+  messageType: "direct" | "session" | "group",
   messageId: string,
   emoji: string
 ) {
@@ -142,7 +201,11 @@ export async function toggleReaction(
   if (!user) throw new Error("Not authenticated");
 
   const column =
-    messageType === "direct" ? "direct_message_id" : "session_message_id";
+    messageType === "direct"
+      ? "direct_message_id"
+      : messageType === "session"
+      ? "session_message_id"
+      : "group_message_id";
 
   // Check if reaction already exists
   const { data: existing } = await supabase

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -63,6 +63,8 @@ export interface Session {
   max_players: number;
   status: SessionStatus;
   last_edited_at: string | null;
+  group_id: string | null;
+  is_private: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -118,4 +120,69 @@ export interface AvailabilityRecurring {
   end_time: string;
   city: string;
   created_at: string;
+}
+
+// ---- Recurring Groups ----
+
+export type GroupMemberRole = "owner" | "admin" | "member";
+export type RsvpStatus = "yes" | "maybe" | "no";
+
+export interface RecurringGroup {
+  id: string;
+  owner_id: string;
+  name: string;
+  description: string | null;
+  day_of_week: number;
+  start_time: string;
+  end_time: string;
+  location: string;
+  city: string;
+  skill_level: SkillLevel;
+  game_type: GameType;
+  max_players: number;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface GroupMember {
+  id: string;
+  group_id: string;
+  user_id: string;
+  role: GroupMemberRole;
+  joined_at: string;
+}
+
+export interface GroupMessage {
+  id: string;
+  group_id: string;
+  user_id: string;
+  content: string;
+  is_edited: boolean;
+  is_deleted: boolean;
+  is_system_message: boolean;
+  created_at: string;
+}
+
+export interface GroupSessionRsvp {
+  id: string;
+  session_id: string;
+  user_id: string;
+  status: RsvpStatus;
+  updated_at: string;
+}
+
+export interface GroupInvitation {
+  id: string;
+  group_id: string;
+  token: string;
+  created_by: string;
+  expires_at: string;
+  created_at: string;
+}
+
+export interface RecurringGroupWithDetails extends RecurringGroup {
+  group_members: (GroupMember & {
+    profiles: Pick<Profile, "id" | "full_name" | "avatar_url" | "skill_level">;
+  })[];
 }

--- a/supabase/migrations/006_recurring_groups.sql
+++ b/supabase/migrations/006_recurring_groups.sql
@@ -1,0 +1,276 @@
+-- ============================================
+-- Migration 006: Recurring Private Groups
+-- Run this in Supabase Dashboard > SQL Editor
+-- ============================================
+
+-- 1. Invite tokens for groups (token-based, no PII search needed)
+CREATE TABLE public.group_invitations (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  group_id UUID NOT NULL,  -- FK added after recurring_groups is created
+  token TEXT NOT NULL UNIQUE,
+  created_by UUID REFERENCES public.profiles(id) ON DELETE CASCADE NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- 2. Recurring groups (the persistent social hub entity)
+CREATE TYPE group_member_role AS ENUM ('owner', 'admin', 'member');
+
+CREATE TABLE public.recurring_groups (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  owner_id UUID REFERENCES public.profiles(id) ON DELETE CASCADE NOT NULL,
+  name TEXT NOT NULL,
+  description TEXT,
+  day_of_week INTEGER NOT NULL CHECK (day_of_week >= 0 AND day_of_week <= 6),
+  start_time TIME NOT NULL,
+  end_time TIME NOT NULL,
+  location TEXT NOT NULL,
+  city TEXT NOT NULL,
+  skill_level skill_level NOT NULL DEFAULT 'Open',
+  game_type game_type NOT NULL DEFAULT 'Either',
+  max_players INTEGER NOT NULL DEFAULT 4 CHECK (max_players >= 2 AND max_players <= 20),
+  is_active BOOLEAN DEFAULT TRUE,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Now add the FK on group_invitations
+ALTER TABLE public.group_invitations
+  ADD CONSTRAINT group_invitations_group_id_fkey
+  FOREIGN KEY (group_id) REFERENCES public.recurring_groups(id) ON DELETE CASCADE;
+
+-- 3. Group members with roles
+CREATE TABLE public.group_members (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  group_id UUID REFERENCES public.recurring_groups(id) ON DELETE CASCADE NOT NULL,
+  user_id UUID REFERENCES public.profiles(id) ON DELETE CASCADE NOT NULL,
+  role group_member_role NOT NULL DEFAULT 'member',
+  joined_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(group_id, user_id)
+);
+
+-- 4. Persistent group-level chat (cross-week)
+CREATE TABLE public.group_messages (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  group_id UUID REFERENCES public.recurring_groups(id) ON DELETE CASCADE NOT NULL,
+  user_id UUID REFERENCES public.profiles(id) ON DELETE CASCADE NOT NULL,
+  content TEXT NOT NULL,
+  is_edited BOOLEAN DEFAULT FALSE,
+  is_deleted BOOLEAN DEFAULT FALSE,
+  is_system_message BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- 5. RSVP per session occurrence (yes/maybe/no)
+CREATE TYPE rsvp_status AS ENUM ('yes', 'maybe', 'no');
+
+CREATE TABLE public.group_session_rsvps (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  session_id UUID REFERENCES public.sessions(id) ON DELETE CASCADE NOT NULL,
+  user_id UUID REFERENCES public.profiles(id) ON DELETE CASCADE NOT NULL,
+  status rsvp_status NOT NULL DEFAULT 'yes',
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(session_id, user_id)
+);
+
+-- 6. Add group_id and is_private to sessions table
+ALTER TABLE public.sessions
+  ADD COLUMN group_id UUID REFERENCES public.recurring_groups(id) ON DELETE SET NULL,
+  ADD COLUMN is_private BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- 7. Extend message_reactions to support group messages
+ALTER TABLE public.message_reactions
+  ADD COLUMN group_message_id UUID REFERENCES public.group_messages(id) ON DELETE CASCADE;
+
+-- Drop old 2-way check constraint and re-add as 3-way
+ALTER TABLE public.message_reactions DROP CONSTRAINT one_message_type;
+ALTER TABLE public.message_reactions ADD CONSTRAINT one_message_type CHECK (
+  (direct_message_id IS NOT NULL AND session_message_id IS NULL AND group_message_id IS NULL) OR
+  (direct_message_id IS NULL AND session_message_id IS NOT NULL AND group_message_id IS NULL) OR
+  (direct_message_id IS NULL AND session_message_id IS NULL AND group_message_id IS NOT NULL)
+);
+
+ALTER TABLE public.message_reactions
+  ADD CONSTRAINT unique_group_reaction UNIQUE(user_id, emoji, group_message_id);
+
+-- 8. Indexes
+CREATE INDEX idx_sessions_group ON public.sessions(group_id);
+CREATE INDEX idx_group_invitations_token ON public.group_invitations(token);
+CREATE INDEX idx_group_invitations_group ON public.group_invitations(group_id);
+CREATE INDEX idx_group_members_group ON public.group_members(group_id);
+CREATE INDEX idx_group_members_user ON public.group_members(user_id);
+CREATE INDEX idx_group_messages_group ON public.group_messages(group_id, created_at);
+CREATE INDEX idx_rsvps_session ON public.group_session_rsvps(session_id);
+CREATE INDEX idx_rsvps_user ON public.group_session_rsvps(user_id);
+CREATE INDEX idx_reactions_group ON public.message_reactions(group_message_id);
+
+-- 9. Auto-update trigger for recurring_groups
+CREATE TRIGGER update_recurring_groups_updated_at
+  BEFORE UPDATE ON public.recurring_groups
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- ============================================
+-- Row Level Security
+-- ============================================
+
+ALTER TABLE public.recurring_groups ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.group_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.group_messages ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.group_session_rsvps ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.group_invitations ENABLE ROW LEVEL SECURITY;
+
+-- recurring_groups: only members can read
+CREATE POLICY "Group members can read their groups"
+  ON public.recurring_groups FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.group_members gm
+      WHERE gm.group_id = recurring_groups.id
+      AND gm.user_id = (SELECT auth.uid())
+    )
+  );
+
+CREATE POLICY "Authenticated users can create groups"
+  ON public.recurring_groups FOR INSERT TO authenticated
+  WITH CHECK ((SELECT auth.uid()) = owner_id);
+
+CREATE POLICY "Owners and admins can update groups"
+  ON public.recurring_groups FOR UPDATE TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.group_members gm
+      WHERE gm.group_id = recurring_groups.id
+      AND gm.user_id = (SELECT auth.uid())
+      AND gm.role IN ('owner', 'admin')
+    )
+  );
+
+CREATE POLICY "Only owner can delete group"
+  ON public.recurring_groups FOR DELETE TO authenticated
+  USING ((SELECT auth.uid()) = owner_id);
+
+-- group_members: members can read all members of their shared groups
+CREATE POLICY "Members can view group members"
+  ON public.group_members FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.group_members gm2
+      WHERE gm2.group_id = group_members.group_id
+      AND gm2.user_id = (SELECT auth.uid())
+    )
+  );
+
+CREATE POLICY "Owners and admins can add members"
+  ON public.group_members FOR INSERT TO authenticated
+  WITH CHECK (
+    (SELECT auth.uid()) = user_id  -- owner adding themselves on creation
+    OR EXISTS (
+      SELECT 1 FROM public.group_members gm
+      WHERE gm.group_id = group_members.group_id
+      AND gm.user_id = (SELECT auth.uid())
+      AND gm.role IN ('owner', 'admin')
+    )
+  );
+
+CREATE POLICY "Members can be removed by admins or leave themselves"
+  ON public.group_members FOR DELETE TO authenticated
+  USING (
+    (SELECT auth.uid()) = user_id
+    OR EXISTS (
+      SELECT 1 FROM public.group_members gm
+      WHERE gm.group_id = group_members.group_id
+      AND gm.user_id = (SELECT auth.uid())
+      AND gm.role IN ('owner', 'admin')
+    )
+  );
+
+-- group_messages
+CREATE POLICY "Group members can read group messages"
+  ON public.group_messages FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.group_members gm
+      WHERE gm.group_id = group_messages.group_id
+      AND gm.user_id = (SELECT auth.uid())
+    )
+  );
+
+CREATE POLICY "Group members can send messages"
+  ON public.group_messages FOR INSERT TO authenticated
+  WITH CHECK (
+    (SELECT auth.uid()) = user_id
+    AND EXISTS (
+      SELECT 1 FROM public.group_members gm
+      WHERE gm.group_id = group_messages.group_id
+      AND gm.user_id = (SELECT auth.uid())
+    )
+  );
+
+CREATE POLICY "Users can update own group messages"
+  ON public.group_messages FOR UPDATE TO authenticated
+  USING ((SELECT auth.uid()) = user_id)
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+-- group_session_rsvps
+CREATE POLICY "Group members can read RSVPs"
+  ON public.group_session_rsvps FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.sessions s
+      JOIN public.group_members gm ON gm.group_id = s.group_id
+      WHERE s.id = group_session_rsvps.session_id
+      AND gm.user_id = (SELECT auth.uid())
+    )
+  );
+
+CREATE POLICY "Members can set own RSVP"
+  ON public.group_session_rsvps FOR INSERT TO authenticated
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+CREATE POLICY "Members can update own RSVP"
+  ON public.group_session_rsvps FOR UPDATE TO authenticated
+  USING ((SELECT auth.uid()) = user_id)
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+-- group_invitations: only admins can manage; anyone (via admin client) can read by token
+CREATE POLICY "Admins can manage invitations"
+  ON public.group_invitations FOR ALL TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.group_members gm
+      WHERE gm.group_id = group_invitations.group_id
+      AND gm.user_id = (SELECT auth.uid())
+      AND gm.role IN ('owner', 'admin')
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.group_members gm
+      WHERE gm.group_id = group_invitations.group_id
+      AND gm.user_id = (SELECT auth.uid())
+      AND gm.role IN ('owner', 'admin')
+    )
+  );
+
+-- Update sessions SELECT policy: private sessions only visible to group members
+DROP POLICY IF EXISTS "Sessions viewable by authenticated users" ON public.sessions;
+
+CREATE POLICY "Sessions viewable by authenticated users"
+  ON public.sessions FOR SELECT TO authenticated
+  USING (
+    is_private = FALSE
+    OR (SELECT auth.uid()) = creator_id
+    OR EXISTS (
+      SELECT 1 FROM public.group_members gm
+      WHERE gm.group_id = sessions.group_id
+      AND gm.user_id = (SELECT auth.uid())
+    )
+  );
+
+-- Also allow unauthenticated reads for public sessions (needed for admin client bypass pattern)
+-- The admin client bypasses RLS so this is handled in app code, not here.
+
+-- 10. Enable realtime for new tables
+ALTER PUBLICATION supabase_realtime ADD TABLE public.group_messages;
+ALTER PUBLICATION supabase_realtime ADD TABLE public.group_session_rsvps;
+ALTER PUBLICATION supabase_realtime ADD TABLE public.group_members;

--- a/supabase/migrations/007_fix_group_rls.sql
+++ b/supabase/migrations/007_fix_group_rls.sql
@@ -1,0 +1,116 @@
+-- ============================================
+-- Migration 007: Fix infinite recursion in group RLS policies
+-- The group_members SELECT policy was querying group_members to check membership,
+-- which triggered itself → infinite loop.
+-- Fix: SECURITY DEFINER helper functions bypass RLS for membership checks.
+-- ============================================
+
+-- 1. Create helper functions (SECURITY DEFINER runs as postgres, bypasses RLS)
+CREATE OR REPLACE FUNCTION public.is_group_member(p_group_id UUID)
+RETURNS BOOLEAN
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.group_members
+    WHERE group_id = p_group_id
+    AND user_id = (SELECT auth.uid())
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_group_admin(p_group_id UUID)
+RETURNS BOOLEAN
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.group_members
+    WHERE group_id = p_group_id
+    AND user_id = (SELECT auth.uid())
+    AND role IN ('owner', 'admin')
+  );
+$$;
+
+-- 2. Drop all the recursive policies
+
+-- recurring_groups
+DROP POLICY IF EXISTS "Group members can read their groups" ON public.recurring_groups;
+DROP POLICY IF EXISTS "Owners and admins can update groups" ON public.recurring_groups;
+
+-- group_members
+DROP POLICY IF EXISTS "Members can view group members" ON public.group_members;
+DROP POLICY IF EXISTS "Owners and admins can add members" ON public.group_members;
+DROP POLICY IF EXISTS "Members can be removed by admins or leave themselves" ON public.group_members;
+
+-- group_messages
+DROP POLICY IF EXISTS "Group members can read group messages" ON public.group_messages;
+DROP POLICY IF EXISTS "Group members can send messages" ON public.group_messages;
+
+-- group_session_rsvps
+DROP POLICY IF EXISTS "Group members can read RSVPs" ON public.group_session_rsvps;
+
+-- group_invitations
+DROP POLICY IF EXISTS "Admins can manage invitations" ON public.group_invitations;
+
+-- 3. Re-create all policies using the helper functions (no recursion)
+
+-- recurring_groups
+CREATE POLICY "Group members can read their groups"
+  ON public.recurring_groups FOR SELECT TO authenticated
+  USING (public.is_group_member(id));
+
+CREATE POLICY "Owners and admins can update groups"
+  ON public.recurring_groups FOR UPDATE TO authenticated
+  USING (public.is_group_admin(id));
+
+-- group_members: use the function for SELECT (prevents recursion)
+CREATE POLICY "Members can view group members"
+  ON public.group_members FOR SELECT TO authenticated
+  USING (public.is_group_member(group_id));
+
+-- INSERT: allow self-insert (owner bootstrapping) OR admin adding someone
+CREATE POLICY "Owners and admins can add members"
+  ON public.group_members FOR INSERT TO authenticated
+  WITH CHECK (
+    (SELECT auth.uid()) = user_id
+    OR public.is_group_admin(group_id)
+  );
+
+-- DELETE: self-leave OR admin removing
+CREATE POLICY "Members can be removed by admins or leave themselves"
+  ON public.group_members FOR DELETE TO authenticated
+  USING (
+    (SELECT auth.uid()) = user_id
+    OR public.is_group_admin(group_id)
+  );
+
+-- group_messages
+CREATE POLICY "Group members can read group messages"
+  ON public.group_messages FOR SELECT TO authenticated
+  USING (public.is_group_member(group_id));
+
+CREATE POLICY "Group members can send messages"
+  ON public.group_messages FOR INSERT TO authenticated
+  WITH CHECK (
+    (SELECT auth.uid()) = user_id
+    AND public.is_group_member(group_id)
+  );
+
+-- group_session_rsvps: check membership via session's group_id
+CREATE POLICY "Group members can read RSVPs"
+  ON public.group_session_rsvps FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.sessions s
+      WHERE s.id = group_session_rsvps.session_id
+      AND public.is_group_member(s.group_id)
+    )
+  );
+
+-- group_invitations
+CREATE POLICY "Admins can manage invitations"
+  ON public.group_invitations FOR ALL TO authenticated
+  USING (public.is_group_admin(group_id))
+  WITH CHECK (public.is_group_admin(group_id));


### PR DESCRIPTION
## 🏸 Feature: Private Recurring Groups

A WhatsApp-style social hub for regular badminton crews — persistent group chat,
auto-generated weekly sessions, RSVP tracking, and invite-link membership.

---

## Database — new migrations

### `006_recurring_groups.sql`
New tables:

| Table | Purpose |
|---|---|
| `recurring_groups` | Group config (day, time, location, skill level) |
| `group_members` | Members with roles: `owner`, `admin`, `member` |
| `group_messages` | Persistent group chat with reaction support |
| `group_session_rsvps` | Per-member RSVP (`yes` / `no` / `maybe`) per session |
| `group_invitations` | Time-limited invite tokens (24 h TTL) |

`sessions` table extended with `group_id` (FK) and `is_private` columns.

### `007_fix_group_rls.sql`
Fixed infinite RLS recursion: the `group_members` SELECT policy was querying
`group_members` to check membership → triggered itself → infinite loop.

**Fix:** two `SECURITY DEFINER` helper functions (`is_group_member`,
`is_group_admin`) that bypass RLS internally, used by all group policies.

Also fixed a chicken-and-egg bug in `createRecurringGroup` — the owner
couldn't read back their newly created group because they weren't in
`group_members` yet. Resolved by using `createAdminClient()` for the
group insert + owner member insert sequence.

---

## Server actions

### `src/lib/actions/groups.ts`
| Action | Description |
|---|---|
| `createRecurringGroup` | Creates group, adds owner as member, generates 4 initial sessions in background |
| `generateGroupSessions` | Bulk-inserts sessions + participants + RSVPs + system chat messages + email notifications |
| `rollGroupSessions` | Called on group page load; generates one more session when the latest is within 7 days |
| `generateInviteLink` | Creates a 24 h invite token |
| `revokeInviteLink` | Deletes the active invite |
| `acceptInvite` | Validates token, adds user to group + all upcoming sessions, posts system message |
| `removeMember` | Admin/owner removes a member (or self-leave); cleans up sessions + RSVPs |
| `updateGroupRsvp` | Upserts RSVP status for a session |
| `updateGroup` | Updates group settings; posts a system message listing what changed |
| `promoteMember` | Owner promotes a member to admin |

### `src/lib/actions/messages.ts`
- Group message send + real-time fetch
- `toggleReaction` extended to support group messages

---

## UI components — `src/components/groups/`

| Component | Description |
|---|---|
| `group-chat.tsx` | Real-time chat panel with reactions |
| `group-session-card.tsx` | Session card with RSVP buttons (Yes / Maybe / No) |
| `member-list.tsx` | Member list with promote / remove actions |
| `invite-link-panel.tsx` | Generate / copy / revoke invite link |
| `group-form.tsx` | Create / edit group form |
| `group-card.tsx` | Card shown on the groups list page |
| `join-group-button.tsx` | CTA button on the public invite landing page |

---

## Pages

| Route | Description |
|---|---|
| `/groups` | Lists all groups the user belongs to |
| `/groups/new` | Create a new recurring group |
| `/groups/[id]` | Group hub — chat, schedule, members tabs |
| `/groups/[id]/edit` | Edit group settings (owner/admin only) |
| `/join/[token]` | Public invite landing — works without login, redirects to auth |

---

## Patches to existing files

- `sessions/page.tsx` — added `.eq("is_private", false)` so group sessions
  don't appear in the public session feed
- `navbar.tsx` — added **My Groups** nav link
- `sessions/[id]/page.tsx` — group sessions show **Open Group Chat** button
  instead of the per-session chat
