### PR TITLE
adding private sessions new changes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ MAIL_PASSWORD=
 MAIL_ENCRYPTION=tls
 MAIL_FROM_ADDRESS=
 MAIL_FROM_NAME=
+
+# Vercel Cron — set a random secret string, add same value in Vercel dashboard
+CRON_SECRET=

--- a/src/app/(protected)/groups/[id]/page.tsx
+++ b/src/app/(protected)/groups/[id]/page.tsx
@@ -66,9 +66,17 @@ export default async function GroupDetailPage({
   const currentUserRole: GroupMemberRole = currentMember?.role ?? "member";
   const canManage = currentUserRole === "owner" || currentUserRole === "admin";
 
-  // Filter and sort upcoming sessions
+  // End of this week (Sunday = end of week, or next 7 days from today)
+  const endOfWeek = new Date();
+  endOfWeek.setDate(endOfWeek.getDate() + (7 - endOfWeek.getDay()));
+  const endOfWeekStr = endOfWeek.toISOString().split("T")[0];
+
+  // Filter to this week's sessions only, sorted ascending
   const upcomingSessions = ((group.sessions as any[]) ?? [])
-    .filter((s: { date: string; status: string }) => s.date >= today && s.status !== "cancelled")
+    .filter(
+      (s: { date: string; status: string }) =>
+        s.date >= today && s.date <= endOfWeekStr && s.status !== "cancelled"
+    )
     .sort((a: { date: string }, b: { date: string }) => a.date.localeCompare(b.date));
 
   // Active invite link (non-expired)
@@ -127,25 +135,16 @@ export default async function GroupDetailPage({
       </div>
 
       {/* Main tabs */}
-      <Tabs defaultValue="chat" className="flex-1">
+      <Tabs defaultValue="schedule" className="flex-1">
         <TabsList className="w-full">
-          <TabsTrigger value="chat" className="flex-1">Chat</TabsTrigger>
           <TabsTrigger value="schedule" className="flex-1">
             Schedule{upcomingSessions.length > 0 && ` (${upcomingSessions.length})`}
           </TabsTrigger>
+          <TabsTrigger value="chat" className="flex-1">Chat</TabsTrigger>
           <TabsTrigger value="members" className="flex-1">
             Members ({(group.group_members as any[]).length})
           </TabsTrigger>
         </TabsList>
-
-        {/* Chat tab */}
-        <TabsContent value="chat" className="mt-4">
-          <Card className="overflow-hidden">
-            <div className="h-[calc(100vh-20rem)] flex flex-col">
-              <GroupChat groupId={id} currentUserId={user.id} />
-            </div>
-          </Card>
-        </TabsContent>
 
         {/* Schedule tab */}
         <TabsContent value="schedule" className="mt-4 space-y-3">
@@ -163,6 +162,15 @@ export default async function GroupDetailPage({
               />
             ))
           )}
+        </TabsContent>
+
+        {/* Chat tab */}
+        <TabsContent value="chat" className="mt-4">
+          <Card className="overflow-hidden">
+            <div className="h-[calc(100vh-20rem)] flex flex-col">
+              <GroupChat groupId={id} currentUserId={user.id} />
+            </div>
+          </Card>
         </TabsContent>
 
         {/* Members tab */}

--- a/src/app/api/cron/session-reminders/route.ts
+++ b/src/app/api/cron/session-reminders/route.ts
@@ -1,0 +1,124 @@
+import { NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { sendEmail } from "@/lib/email/smtp";
+import { format } from "date-fns";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  // Verify this is called by Vercel Cron (or locally via the secret)
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const admin = createAdminClient();
+
+  // Target tomorrow's sessions so members can plan ahead
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const tomorrowStr = tomorrow.toISOString().split("T")[0];
+
+  // Find all group sessions happening tomorrow
+  const { data: sessions, error } = await admin
+    .from("sessions")
+    .select("id, title, start_time, end_time, location, city, group_id, date")
+    .eq("date", tomorrowStr)
+    .not("group_id", "is", null)
+    .in("status", ["open", "full"]);
+
+  if (error) {
+    console.error("Cron: failed to fetch today's sessions", error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  if (!sessions || sessions.length === 0) {
+    return NextResponse.json({ message: "No group sessions tomorrow" });
+  }
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+  const dayNames = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+  const tomorrowDayName = dayNames[tomorrow.getDay()];
+  const formattedDate = format(tomorrow, "MMMM d, yyyy");
+
+  let totalNotified = 0;
+
+  for (const session of sessions) {
+    const groupId = session.group_id as string;
+
+    // Get group members
+    const { data: members } = await admin
+      .from("group_members")
+      .select("user_id")
+      .eq("group_id", groupId);
+
+    if (!members || members.length === 0) continue;
+    const memberIds = members.map((m) => m.user_id);
+
+    // Post a system message in the group chat
+    await admin.from("group_messages").insert({
+      group_id: groupId,
+      user_id: (
+        await admin
+          .from("recurring_groups")
+          .select("owner_id")
+          .eq("id", groupId)
+          .single()
+      ).data?.owner_id,
+      content: `🏸 Reminder: session tomorrow! ${tomorrowDayName} ${formattedDate}, ${session.start_time.slice(0, 5)}–${session.end_time.slice(0, 5)} at ${session.location}. Please confirm your RSVP in the Schedule tab.`,
+      is_system_message: true,
+    });
+
+    // Email members with notifications enabled
+    const { data: profiles } = await admin
+      .from("profiles")
+      .select("id, full_name, email_notifications")
+      .in("id", memberIds)
+      .eq("email_notifications", true);
+
+    if (!profiles || profiles.length === 0) continue;
+
+    const { data: authData } = await admin.auth.admin.listUsers();
+    const emailMap = new Map<string, string>();
+    authData?.users?.forEach((u) => {
+      if (u.email) emailMap.set(u.id, u.email);
+    });
+
+    const groupUrl = `${appUrl}/groups/${groupId}`;
+
+    for (const profile of profiles) {
+      const email = emailMap.get(profile.id);
+      if (!email) continue;
+
+      try {
+        await sendEmail({
+          to: email,
+          subject: `${session.title} — session tomorrow! Confirm your RSVP`,
+          html: `
+            <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
+              <h2 style="color: #1a1a1a; margin: 0 0 16px 0;">Your session is tomorrow 🏸</h2>
+              <p style="color: #374151; margin: 0 0 8px 0;">Hi ${profile.full_name ?? "Player"},</p>
+              <p style="color: #374151; margin: 0 0 16px 0;">Just a reminder that <strong>${session.title}</strong> is happening tomorrow:</p>
+              <div style="background: #f4f4f5; border-radius: 8px; padding: 16px; margin: 0 0 20px 0;">
+                <p style="margin: 4px 0; color: #374151; font-size: 14px;">📅 ${tomorrowDayName}, ${formattedDate}</p>
+                <p style="margin: 4px 0; color: #374151; font-size: 14px;">🕐 ${session.start_time.slice(0, 5)}–${session.end_time.slice(0, 5)}</p>
+                <p style="margin: 4px 0; color: #374151; font-size: 14px;">📍 ${session.location}, ${session.city}</p>
+              </div>
+              <p style="color: #374151; margin: 0 0 16px 0;">Please confirm whether you're coming so your crew can plan ahead.</p>
+              <a href="${groupUrl}" style="display: inline-block; background: #18181b; color: #ffffff; padding: 10px 24px; border-radius: 6px; text-decoration: none; font-weight: bold; font-size: 14px;">Confirm RSVP</a>
+              <p style="color: #9ca3af; font-size: 12px; margin-top: 24px;">You received this because you are a member of ${session.title} on ShuttleMates.</p>
+            </div>
+          `,
+        });
+        totalNotified++;
+      } catch (err) {
+        console.error(`Cron: failed to send reminder to ${profile.id}:`, err);
+      }
+    }
+  }
+
+  return NextResponse.json({
+    message: `Reminders sent for ${sessions.length} session(s), ${totalNotified} member(s) notified`,
+  });
+}

--- a/src/components/groups/group-form.tsx
+++ b/src/components/groups/group-form.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { CityCombobox } from "@/components/ui/city-combobox";
 import {
   Select,
   SelectContent,
@@ -142,12 +143,11 @@ export function GroupForm({ mode, group }: GroupFormProps) {
           />
         </div>
         <div className="space-y-1.5">
-          <Label htmlFor="city">City</Label>
-          <Input
-            id="city"
+          <Label>City</Label>
+          <CityCombobox
             name="city"
-            placeholder="Colombo"
-            defaultValue={group?.city}
+            defaultValue={group?.city ?? ""}
+            placeholder="Select city..."
             required
           />
         </div>

--- a/src/lib/actions/groups.ts
+++ b/src/lib/actions/groups.ts
@@ -141,8 +141,12 @@ export async function generateGroupSessions(
 
   const memberIds = members?.map((m) => m.user_id) ?? [];
 
-  for (const date of newDates) {
+  const dayNames = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+
+  for (let i = 0; i < newDates.length; i++) {
+    const date = newDates[i];
     const dateStr = date.toISOString().split("T")[0];
+    const isFirst = i === 0;
 
     // Insert the session
     const { data: session, error: sessionError } = await admin
@@ -171,23 +175,17 @@ export async function generateGroupSessions(
     }
 
     if (memberIds.length > 0) {
-      // Bulk insert session_participants
       await admin.from("session_participants").insert(
         memberIds.map((uid) => ({ session_id: session.id, user_id: uid }))
       );
-
-      // Bulk insert default yes RSVPs
       await admin.from("group_session_rsvps").insert(
-        memberIds.map((uid) => ({
-          session_id: session.id,
-          user_id: uid,
-          status: "yes",
-        }))
+        memberIds.map((uid) => ({ session_id: session.id, user_id: uid, status: "yes" }))
       );
     }
 
-    // Post system message in group chat for the new session
-    const dayNames = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+    // Only announce the nearest session — skip silent future ones
+    if (!isFirst) continue;
+
     const formattedDate = format(date, "MMMM d, yyyy");
     await admin.from("group_messages").insert({
       group_id: groupId,
@@ -196,7 +194,6 @@ export async function generateGroupSessions(
       is_system_message: true,
     });
 
-    // Send email to members with notifications enabled
     if (memberIds.length > 0) {
       const { data: profiles } = await admin
         .from("profiles")
@@ -629,12 +626,65 @@ export async function updateGroup(
     after(async () => {
       const admin = createAdminClient();
       const changesList = changes.map((c) => `• ${c}`).join("\n");
+
       await admin.from("group_messages").insert({
         group_id: groupId,
         user_id: user.id,
         content: `Group settings updated:\n${changesList}`,
         is_system_message: true,
       });
+
+      // Email members about the changes
+      const { data: members } = await admin
+        .from("group_members")
+        .select("user_id")
+        .eq("group_id", groupId);
+
+      if (!members || members.length === 0) return;
+      const memberIds = members.map((m) => m.user_id);
+
+      const { data: profiles } = await admin
+        .from("profiles")
+        .select("id, full_name, email_notifications")
+        .in("id", memberIds)
+        .eq("email_notifications", true);
+
+      if (!profiles || profiles.length === 0) return;
+
+      const { data: authData } = await admin.auth.admin.listUsers();
+      const emailMap = new Map<string, string>();
+      authData?.users?.forEach((u) => {
+        if (u.email) emailMap.set(u.id, u.email);
+      });
+
+      const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+      const groupUrl = `${appUrl}/groups/${groupId}`;
+      const { sendEmail } = await import("@/lib/email/smtp");
+
+      for (const profile of profiles) {
+        const email = emailMap.get(profile.id);
+        if (!email) continue;
+        try {
+          await sendEmail({
+            to: email,
+            subject: `${newData.name} — group settings updated`,
+            html: `
+              <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
+                <h2 style="color: #1a1a1a; margin: 0 0 16px 0;">Group settings updated</h2>
+                <p style="color: #374151; margin: 0 0 8px 0;">Hi ${profile.full_name ?? "Player"},</p>
+                <p style="color: #374151; margin: 0 0 16px 0;">The settings for your group <strong>${newData.name}</strong> have been updated:</p>
+                <div style="background: #f4f4f5; border-radius: 8px; padding: 16px; margin: 0 0 20px 0; white-space: pre-line; font-size: 14px; color: #374151;">
+${changes.map((c) => `• ${c}`).join("\n")}
+                </div>
+                <a href="${groupUrl}" style="display: inline-block; background: #18181b; color: #ffffff; padding: 10px 24px; border-radius: 6px; text-decoration: none; font-weight: bold; font-size: 14px;">View Group</a>
+                <p style="color: #9ca3af; font-size: 12px; margin-top: 24px;">You received this because you are a member of ${newData.name} on ShuttleMates.</p>
+              </div>
+            `,
+          });
+        } catch (err) {
+          console.error(`Failed to send update email to ${profile.id}:`, err);
+        }
+      }
     });
   }
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/session-reminders",
+      "schedule": "0 7 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Changes

- **Schedule tab first** — default tab is now Schedule (order: Schedule → Chat → Members)
- **This week only in schedule** — sessions filtered to `today → end of this Sunday`
- **City combobox in group form** — replaced plain text input with `CityCombobox` (GeoNames API dropdown)
- **Group edit emails** — `updateGroup` now emails members with notifications enabled when settings change
- **Chat/email spam fix** — `generateGroupSessions` only announces the nearest session; the rest are created silently
- **Day-before reminder cron** — `/api/cron/session-reminders` + `vercel.json` runs daily at 7 AM UTC, finds tomorrow's group sessions, posts a chat reminder and emails members to confirm RSVP
