### PR TITLE
adding gender and age to profiles and sessions

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,9 @@
   "permissions": {
     "allow": [
       "Bash(xargs wc -l)",
-      "Bash(ls \"C:\\\\Users\\\\Thamindu\\\\.claude\\\\projects\\\\c--Users-Thamindu-Downloads-JH-Litarature-shuttlemates\\\\memory\"\" 2>/dev/null || echo \"Directory does not exist \")"
+      "Bash(ls \"C:\\\\Users\\\\Thamindu\\\\.claude\\\\projects\\\\c--Users-Thamindu-Downloads-JH-Litarature-shuttlemates\\\\memory\"\" 2>/dev/null || echo \"Directory does not exist \")",
+      "Bash(ls -la /c/Users/Thamindu/Downloads/JH/Litarature/shuttlemates/src/app/\\\\\\(sessions\\\\\\)/sessions/)",
+      "Bash(cat /c/Users/Thamindu/Downloads/JH/Litarature/shuttlemates/src/app/\\\\\\(sessions\\\\\\)/sessions/[id]/page.tsx)"
     ]
   }
 }

--- a/src/app/(protected)/sessions/[id]/edit/page.tsx
+++ b/src/app/(protected)/sessions/[id]/edit/page.tsx
@@ -45,6 +45,7 @@ export default async function EditSessionPage({
     skill_level: session.skill_level,
     game_type: session.game_type,
     max_players: session.max_players,
+    player_preferences: session.player_preferences ?? null,
   };
 
   return (

--- a/src/app/(sessions)/sessions/[id]/page.tsx
+++ b/src/app/(sessions)/sessions/[id]/page.tsx
@@ -11,7 +11,24 @@ import { CancelSessionButton } from "@/components/sessions/cancel-session-button
 import { EditSessionButton } from "@/components/sessions/edit-session-button";
 import { ConfirmationBanner } from "@/components/sessions/confirmation-banner";
 import { SessionChat } from "@/components/sessions/session-chat";
-import { Calendar, Clock, MapPin, Users } from "lucide-react";
+import { Calendar, Clock, MapPin, Users, UserCheck } from "lucide-react";
+import type { PlayerPreferences } from "@/lib/types/database";
+
+function formatPreferences(prefs: PlayerPreferences): string {
+  const parts: string[] = [];
+  if (prefs.male_slots || prefs.female_slots) {
+    const slots: string[] = [];
+    if (prefs.male_slots) slots.push(`${prefs.male_slots}M`);
+    if (prefs.female_slots) slots.push(`${prefs.female_slots}F`);
+    parts.push(slots.join(" + "));
+  }
+  if (prefs.min_age || prefs.max_age) {
+    if (prefs.min_age && prefs.max_age) parts.push(`Age ${prefs.min_age}–${prefs.max_age}`);
+    else if (prefs.min_age) parts.push(`Age ${prefs.min_age}+`);
+    else if (prefs.max_age) parts.push(`Age up to ${prefs.max_age}`);
+  }
+  return parts.join(" · ");
+}
 import { format } from "date-fns";
 import { TimingBadge } from "@/components/sessions/timing-badge";
 import { Button } from "@/components/ui/button";
@@ -42,7 +59,7 @@ export default async function SessionDetailPage({
         joined_at,
         confirmed,
         confirmation_deadline,
-        profiles(id, full_name, avatar_url, skill_level)
+        profiles(*)
       )
     `
     )
@@ -153,6 +170,15 @@ export default async function SessionDetailPage({
                   </p>
                 </div>
               </div>
+              {session.player_preferences && (
+                <div className="flex items-center gap-3">
+                  <UserCheck className="h-5 w-5 text-muted-foreground" />
+                  <div>
+                    <p className="text-sm text-muted-foreground">Host prefers</p>
+                    <p className="font-medium">{formatPreferences(session.player_preferences)}</p>
+                  </div>
+                </div>
+              )}
             </div>
 
             <Separator />

--- a/src/components/profile/profile-form.tsx
+++ b/src/components/profile/profile-form.tsx
@@ -15,7 +15,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { MultiCityCombobox } from "@/components/ui/city-combobox";
-import type { Profile, SkillLevel } from "@/lib/types/database";
+import type { Profile, SkillLevel, Gender } from "@/lib/types/database";
 
 const SKILL_LEVELS: { value: SkillLevel; label: string; desc: string }[] = [
   { value: "Beginner", label: "Beginner", desc: "Learning basics, casual play" },
@@ -34,6 +34,8 @@ export function ProfileForm({ profile, isOnboarding = false }: ProfileFormProps)
   const [skillLevel, setSkillLevel] = useState<SkillLevel>(
     profile?.skill_level ?? "Beginner"
   );
+  const [gender, setGender] = useState<Gender | "">(profile?.gender ?? "");
+  const [dateOfBirth, setDateOfBirth] = useState(profile?.date_of_birth ?? "");
   const [cities, setCities] = useState<string[]>(
     profile?.city ? profile.city.split(", ").filter(Boolean) : []
   );
@@ -63,6 +65,8 @@ export function ProfileForm({ profile, isOnboarding = false }: ProfileFormProps)
       .update({
         full_name: fullName,
         skill_level: skillLevel,
+        gender: gender || null,
+        date_of_birth: dateOfBirth || null,
         city: cities.join(", "),
         bio,
         profile_complete: true,
@@ -115,6 +119,32 @@ export function ProfileForm({ profile, isOnboarding = false }: ProfileFormProps)
             ))}
           </SelectContent>
         </Select>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="gender">Gender</Label>
+          <Select value={gender} onValueChange={(v) => setGender(v as Gender)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select gender..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="Male">Male</SelectItem>
+              <SelectItem value="Female">Female</SelectItem>
+              <SelectItem value="Prefer not to say">Prefer not to say</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="dateOfBirth">Date of Birth</Label>
+          <Input
+            id="dateOfBirth"
+            type="date"
+            value={dateOfBirth}
+            onChange={(e) => setDateOfBirth(e.target.value)}
+            max={new Date(new Date().setFullYear(new Date().getFullYear() - 10)).toISOString().split("T")[0]}
+            min={new Date(new Date().setFullYear(new Date().getFullYear() - 100)).toISOString().split("T")[0]}
+          />
+        </div>
       </div>
       <div className="space-y-2">
         <Label>Cities you can play in *</Label>

--- a/src/components/sessions/participant-list.tsx
+++ b/src/components/sessions/participant-list.tsx
@@ -4,6 +4,10 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { MessageCircle } from "lucide-react";
 
+function calcAge(dob: string): number {
+  return Math.floor((Date.now() - new Date(dob).getTime()) / 31557600000);
+}
+
 interface Participant {
   user_id: string;
   confirmed?: boolean;
@@ -13,6 +17,8 @@ interface Participant {
     full_name: string | null;
     avatar_url: string | null;
     skill_level: string | null;
+    date_of_birth?: string | null;
+    gender?: string | null;
   };
 }
 
@@ -40,6 +46,15 @@ export function ParticipantList({
           .toUpperCase();
         const isHost = p.user_id === creatorId;
 
+        const genderChar =
+          p.profiles.gender === "Male" ? "M" :
+          p.profiles.gender === "Female" ? "F" :
+          p.profiles.gender === "Prefer not to say" ? "?" : null;
+        const age = p.profiles.date_of_birth ? calcAge(p.profiles.date_of_birth) : null;
+        const genderAgeBadge = genderChar
+          ? age !== null ? `${genderChar} • ${age}` : genderChar
+          : age !== null ? `${age}` : null;
+
         return (
           <div key={p.user_id} className="flex items-center justify-between">
             <div className="flex items-center gap-3">
@@ -57,6 +72,20 @@ export function ParticipantList({
                 {p.profiles.skill_level && (
                   <Badge variant="secondary" className="text-xs">
                     {p.profiles.skill_level}
+                  </Badge>
+                )}
+                {genderAgeBadge && (
+                  <Badge
+                    variant="outline"
+                    className={`text-xs ${
+                      p.profiles.gender === "Male"
+                        ? "border-blue-300 text-blue-700 dark:border-blue-700 dark:text-blue-300"
+                        : p.profiles.gender === "Female"
+                        ? "border-purple-300 text-purple-700 dark:border-purple-700 dark:text-purple-300"
+                        : "text-muted-foreground"
+                    }`}
+                  >
+                    {genderAgeBadge}
                   </Badge>
                 )}
                 {showConfirmationStatus && !isHost && (

--- a/src/components/sessions/session-form.tsx
+++ b/src/components/sessions/session-form.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/components/ui/select";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CityCombobox } from "@/components/ui/city-combobox";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, ChevronDown, ChevronUp } from "lucide-react";
 import type { SessionFormData } from "@/lib/types/database";
 
 interface SessionFormProps {
@@ -42,6 +42,13 @@ export function SessionForm({ mode = "create", initialData }: SessionFormProps) 
   const [overlappingSessions, setOverlappingSessions] = useState<{ start_time: string; end_time: string }[]>([]);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
 
+  // Advanced player preferences
+  const [showAdvanced, setShowAdvanced] = useState(!!initialData?.player_preferences);
+  const [maleSlots, setMaleSlots] = useState(initialData?.player_preferences?.male_slots?.toString() ?? "");
+  const [femaleSlots, setFemaleSlots] = useState(initialData?.player_preferences?.female_slots?.toString() ?? "");
+  const [minAge, setMinAge] = useState(initialData?.player_preferences?.min_age?.toString() ?? "");
+  const [maxAge, setMaxAge] = useState(initialData?.player_preferences?.max_age?.toString() ?? "");
+
   useEffect(() => {
     if (!city || !date || !startTime || !endTime) return;
 
@@ -66,6 +73,25 @@ export function SessionForm({ mode = "create", initialData }: SessionFormProps) 
   const handleSubmit = async (formData: FormData) => {
     setLoading(true);
     setError(null);
+
+    // Validate session is not in the past (browser has local timezone)
+    const sessionStart = new Date(`${formData.get("date")}T${formData.get("start_time")}`);
+    if (sessionStart < new Date()) {
+      setError("Session start time has already passed");
+      setLoading(false);
+      return;
+    }
+
+    // Validate slot totals don't exceed max_players
+    const maxPlayers = parseInt(formData.get("max_players") as string) || 0;
+    const ms = parseInt(maleSlots) || 0;
+    const fs = parseInt(femaleSlots) || 0;
+    if (ms + fs > maxPlayers) {
+      setError(`Gender slot total (${ms}M + ${fs}F = ${ms + fs}) exceeds max players (${maxPlayers})`);
+      setLoading(false);
+      return;
+    }
+
     try {
       if (isEdit && initialData) {
         const result = await editSession(initialData.id, formData);
@@ -232,6 +258,87 @@ export function SessionForm({ mode = "create", initialData }: SessionFormProps) 
                 required
               />
             </div>
+          </div>
+
+          {/* Advanced player preferences */}
+          <div className="border rounded-md">
+            <button
+              type="button"
+              onClick={() => setShowAdvanced((v) => !v)}
+              className="flex items-center justify-between w-full px-4 py-3 text-sm font-medium text-left hover:bg-muted/50 transition-colors rounded-md"
+            >
+              <span>Player preferences <span className="text-muted-foreground font-normal">(optional)</span></span>
+              {showAdvanced ? <ChevronUp className="h-4 w-4 text-muted-foreground" /> : <ChevronDown className="h-4 w-4 text-muted-foreground" />}
+            </button>
+            {showAdvanced && (
+              <div className="px-4 pb-4 space-y-4 border-t pt-4">
+                <p className="text-xs text-muted-foreground">
+                  Let players know what mix you&apos;re looking for. This is informational only — anyone can still join.
+                </p>
+                <div className="space-y-2">
+                  <Label className="text-sm">Gender slots needed</Label>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1">
+                      <Label htmlFor="male_slots" className="text-xs text-muted-foreground">Male</Label>
+                      <Input
+                        id="male_slots"
+                        name="male_slots"
+                        type="number"
+                        min={0}
+                        max={20}
+                        placeholder="0"
+                        value={maleSlots}
+                        onChange={(e) => setMaleSlots(e.target.value)}
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label htmlFor="female_slots" className="text-xs text-muted-foreground">Female</Label>
+                      <Input
+                        id="female_slots"
+                        name="female_slots"
+                        type="number"
+                        min={0}
+                        max={20}
+                        placeholder="0"
+                        value={femaleSlots}
+                        onChange={(e) => setFemaleSlots(e.target.value)}
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  <Label className="text-sm">Age range</Label>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1">
+                      <Label htmlFor="min_age" className="text-xs text-muted-foreground">Min age</Label>
+                      <Input
+                        id="min_age"
+                        name="min_age"
+                        type="number"
+                        min={10}
+                        max={100}
+                        placeholder="Any"
+                        value={minAge}
+                        onChange={(e) => setMinAge(e.target.value)}
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label htmlFor="max_age" className="text-xs text-muted-foreground">Max age</Label>
+                      <Input
+                        id="max_age"
+                        name="max_age"
+                        type="number"
+                        min={10}
+                        max={100}
+                        placeholder="Any"
+                        value={maxAge}
+                        onChange={(e) => setMaxAge(e.target.value)}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
           </div>
 
           <Button type="submit" className="w-full" disabled={loading}>

--- a/src/lib/actions/sessions.ts
+++ b/src/lib/actions/sessions.ts
@@ -4,7 +4,22 @@ import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { after } from "next/server";
-import type { GameType, SkillLevel } from "@/lib/types/database";
+import type { GameType, PlayerPreferences, SkillLevel } from "@/lib/types/database";
+
+function parsePlayerPreferences(formData: FormData): PlayerPreferences | null {
+  const maleSlots = parseInt(formData.get("male_slots") as string);
+  const femaleSlots = parseInt(formData.get("female_slots") as string);
+  const minAge = parseInt(formData.get("min_age") as string);
+  const maxAge = parseInt(formData.get("max_age") as string);
+
+  const prefs: PlayerPreferences = {};
+  if (!isNaN(maleSlots) && maleSlots > 0) prefs.male_slots = maleSlots;
+  if (!isNaN(femaleSlots) && femaleSlots > 0) prefs.female_slots = femaleSlots;
+  if (!isNaN(minAge) && minAge > 0) prefs.min_age = minAge;
+  if (!isNaN(maxAge) && maxAge > 0) prefs.max_age = maxAge;
+
+  return Object.keys(prefs).length > 0 ? prefs : null;
+}
 
 export async function createSession(formData: FormData) {
   const supabase = await createClient();
@@ -14,18 +29,39 @@ export async function createSession(formData: FormData) {
 
   if (!user) throw new Error("Not authenticated");
 
+  const date = formData.get("date") as string;
+  const startTime = formData.get("start_time") as string;
+  const maxPlayers = parseInt(formData.get("max_players") as string);
+  const playerPreferences = parsePlayerPreferences(formData);
+
+  // Validate date is not in the past
+  const today = new Date();
+  const todayStr = today.toISOString().split("T")[0];
+  if (date < todayStr) {
+    throw new Error("Cannot create a session in the past");
+  }
+
+  // Validate slot totals
+  if (playerPreferences) {
+    const slotTotal = (playerPreferences.male_slots ?? 0) + (playerPreferences.female_slots ?? 0);
+    if (slotTotal > maxPlayers) {
+      throw new Error(`Gender slot total (${slotTotal}) exceeds max players (${maxPlayers})`);
+    }
+  }
+
   const sessionData = {
     creator_id: user.id,
     title: formData.get("title") as string,
     description: (formData.get("description") as string) || null,
-    date: formData.get("date") as string,
-    start_time: formData.get("start_time") as string,
+    date,
+    start_time: startTime,
     end_time: formData.get("end_time") as string,
     location: formData.get("location") as string,
     city: formData.get("city") as string,
     skill_level: formData.get("skill_level") as SkillLevel,
     game_type: formData.get("game_type") as GameType,
-    max_players: parseInt(formData.get("max_players") as string),
+    max_players: maxPlayers,
+    player_preferences: playerPreferences,
   };
 
   const { data, error } = await supabase
@@ -309,6 +345,7 @@ export async function editSession(
     skill_level: formData.get("skill_level") as SkillLevel,
     game_type: formData.get("game_type") as GameType,
     max_players: parseInt(formData.get("max_players") as string),
+    player_preferences: parsePlayerPreferences(formData),
   };
 
   // Detect what changed
@@ -323,9 +360,21 @@ export async function editSession(
   if (session.skill_level !== newData.skill_level) changes.push(`Skill Level: ${newData.skill_level}`);
   if (session.game_type !== newData.game_type) changes.push(`Game Type: ${newData.game_type}`);
   if (session.max_players !== newData.max_players) changes.push(`Max Players: ${newData.max_players}`);
+  if (JSON.stringify(session.player_preferences ?? null) !== JSON.stringify(newData.player_preferences)) changes.push("Player preferences updated");
 
   if (changes.length === 0) {
     return { success: false, error: "No changes detected" };
+  }
+
+  // Validate slot totals don't exceed max_players
+  if (newData.player_preferences) {
+    const slotTotal = (newData.player_preferences.male_slots ?? 0) + (newData.player_preferences.female_slots ?? 0);
+    if (slotTotal > newData.max_players) {
+      return {
+        success: false,
+        error: `Gender slot total (${slotTotal}) exceeds max players (${newData.max_players})`,
+      };
+    }
   }
 
   // Validate max_players >= current participant count

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -12,9 +12,17 @@ export interface Profile {
   city: string | null;
   bio: string | null;
   avatar_url: string | null;
+  date_of_birth: string | null;
   profile_complete: boolean;
   created_at: string;
   updated_at: string;
+}
+
+export interface PlayerPreferences {
+  male_slots?: number;
+  female_slots?: number;
+  min_age?: number;
+  max_age?: number;
 }
 
 export interface SessionMessage {
@@ -65,6 +73,7 @@ export interface Session {
   last_edited_at: string | null;
   group_id: string | null;
   is_private: boolean;
+  player_preferences: PlayerPreferences | null;
   created_at: string;
   updated_at: string;
 }
@@ -90,6 +99,7 @@ export interface SessionFormData {
   skill_level: SkillLevel;
   game_type: GameType;
   max_players: number;
+  player_preferences: PlayerPreferences | null;
 }
 
 export interface SessionWithCreator extends Session {
@@ -98,7 +108,7 @@ export interface SessionWithCreator extends Session {
 
 export interface SessionWithParticipants extends SessionWithCreator {
   session_participants: (SessionParticipant & {
-    profiles: Pick<Profile, "id" | "full_name" | "avatar_url" | "skill_level">;
+    profiles: Pick<Profile, "id" | "full_name" | "avatar_url" | "skill_level" | "date_of_birth" | "gender">;
   })[];
 }
 

--- a/supabase/migrations/008_age_gender_preferences.sql
+++ b/supabase/migrations/008_age_gender_preferences.sql
@@ -1,0 +1,9 @@
+-- Add date of birth to profiles (for age calculation)
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS date_of_birth DATE;
+
+-- Add gender to profiles
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS gender TEXT CHECK (gender IN ('Male', 'Female', 'Prefer not to say'));
+
+-- Add player preferences to sessions (soft/informational only, no enforcement)
+-- Shape: { male_slots?: number, female_slots?: number, min_age?: number, max_age?: number }
+ALTER TABLE public.sessions ADD COLUMN IF NOT EXISTS player_preferences JSONB;


### PR DESCRIPTION
## What's changed

### Age & gender on profiles
- Added **Gender** (Male / Female / Prefer not to say) and **Date of Birth** fields to the Edit Profile form
- Migration: `gender TEXT` + `date_of_birth DATE` columns on `profiles`

### Player preferences on sessions
- New collapsible **"Player preferences (optional)"** section on the session form
- Host can specify desired male slots, female slots, and age range (min/max)
- Preferences are informational only — anyone can still join
- Shown on the session detail page as **"Host prefers: 2M + 1F · Age 20–30"**

### Participant gender/age badges
- Each participant in the players list now shows a coloured **M • 25** / **F • 22** badge
- Badge only appears when the user has completed their profile

### Validation fixes
- Gender slot total cannot exceed `max_players` (client + server)
- Cannot create a session with a past date (server) or past start time today (client)

### DB
```sql
ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS date_of_birth DATE;
ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS gender TEXT CHECK (gender IN ('Male', 'Female', 'Prefer not to say'));
ALTER TABLE public.sessions ADD COLUMN IF NOT EXISTS player_preferences JSONB;
