### PR TITLE
make chat experience better

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,10 @@
       "Bash(gh auth status)",
       "Bash(xargs grep -l \"My Sessions\")",
       "Bash(npm install:*)",
-      "Bash(npm run:*)"
+      "Bash(npm run:*)",
+      "Bash(grep -r @mention /c/Users/Thamindu/Downloads/JH/Litarature/shuttlemates/src --include=*.ts --include=*.tsx)",
+      "Bash(npx tsc:*)",
+      "Bash(node -e \":*)"
     ]
   }
 }

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -29,7 +29,7 @@ export default async function ProtectedLayout({
   ]);
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-screen flex flex-col page-texture">
       <Navbar
         userName={profile?.full_name ?? null}
         avatarUrl={profile?.avatar_url ?? null}

--- a/src/app/(protected)/messages/[userId]/page.tsx
+++ b/src/app/(protected)/messages/[userId]/page.tsx
@@ -18,6 +18,9 @@ export default async function DirectMessagePage({
 
   if (!user) redirect("/login");
 
+  // Prevent messaging yourself
+  if (userId === user.id) redirect("/messages");
+
   // Fetch the other user's profile
   const { data: otherUser } = await supabase
     .from("profiles")

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -50,6 +50,8 @@
 :root {
   --radius: 0.625rem;
   --background: oklch(1 0 0);
+  --texture-line: rgba(0, 0, 0, 0.028);
+  --texture-dot: rgba(0, 0, 0, 0.07);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
@@ -84,6 +86,8 @@
 
 .dark {
   --background: oklch(0.145 0 0);
+  --texture-line: rgba(255, 255, 255, 0.04);
+  --texture-dot: rgba(255, 255, 255, 0.055);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
   --card-foreground: oklch(0.985 0 0);
@@ -171,4 +175,21 @@
 .hero-grid {
   background-image: radial-gradient(circle, currentColor 1px, transparent 1px);
   background-size: 32px 32px;
+}
+
+/* ── Chat wallpaper: fine diagonal stripe ─────── */
+.chat-texture {
+  background-image: repeating-linear-gradient(
+    135deg,
+    transparent 0px,
+    transparent 10px,
+    var(--texture-line) 10px,
+    var(--texture-line) 11px
+  );
+}
+
+/* ── Page background: subtle dot grid ────────── */
+.page-texture {
+  background-image: radial-gradient(circle, var(--texture-dot) 1px, transparent 1px);
+  background-size: 26px 26px;
 }

--- a/src/components/groups/group-chat.tsx
+++ b/src/components/groups/group-chat.tsx
@@ -10,8 +10,9 @@ import {
 } from "@/lib/actions/messages";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Send, Pencil, Trash2, Smile, X, Check } from "lucide-react";
+import { Send, Pencil, Trash2, Smile, X, Check, ChevronDown } from "lucide-react";
 import { toast } from "sonner";
 import { formatDistanceToNow } from "date-fns";
 import dynamic from "next/dynamic";
@@ -63,6 +64,16 @@ interface GroupChatProps {
   members: Member[];
 }
 
+function formatDateLabel(dateStr: string): string {
+  const date = new Date(dateStr);
+  const today = new Date();
+  const yesterday = new Date();
+  yesterday.setDate(today.getDate() - 1);
+  if (date.toDateString() === today.toDateString()) return "Today";
+  if (date.toDateString() === yesterday.toDateString()) return "Yesterday";
+  return date.toLocaleDateString(undefined, { weekday: "long", month: "long", day: "numeric" });
+}
+
 /** Render message content, highlighting @mentions */
 function renderContent(content: string, currentUserName: string | null) {
   const parts = content.split(/(@\S+)/g);
@@ -97,6 +108,9 @@ export function GroupChat({
   const [reactions, setReactions] = useState<Record<string, Reaction[]>>({});
   const [emojiPickerMsgId, setEmojiPickerMsgId] = useState<string | null>(null);
   const [showInputEmoji, setShowInputEmoji] = useState(false);
+  const [typingUsers, setTypingUsers] = useState<string[]>([]);
+  const [isScrolledUp, setIsScrolledUp] = useState(false);
+  const [newMsgCount, setNewMsgCount] = useState(0);
 
   // @mention state
   const [mentionSearch, setMentionSearch] = useState<string | null>(null);
@@ -105,8 +119,12 @@ export function GroupChat({
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const editInputRef = useRef<HTMLInputElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const prevMessageCountRef = useRef<number>(0);
+  const hasInitialScrolledRef = useRef(false);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const channelRef = useRef<any>(null);
+  const typingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const fetchMessages = useCallback(async () => {
     const supabase = createClient();
@@ -153,7 +171,7 @@ export function GroupChat({
     fetchMessages();
   }, [fetchMessages]);
 
-  // Realtime subscription
+  // Realtime subscription + presence for typing indicators
   useEffect(() => {
     const supabase = createClient();
 
@@ -239,16 +257,39 @@ export function GroupChat({
           });
         }
       )
-      .subscribe();
+      .on("presence", { event: "sync" }, () => {
+        const state = channel.presenceState<{
+          userId: string;
+          userName: string;
+          typing: boolean;
+        }>();
+        const typing = Object.values(state)
+          .flat()
+          .filter((p) => p.typing && p.userId !== currentUserId)
+          .map((p) => p.userName || "Someone");
+        setTypingUsers(typing);
+      })
+      .subscribe(async (status: string) => {
+        if (status === "SUBSCRIBED") {
+          await channel.track({
+            userId: currentUserId,
+            userName: currentUserName ?? "",
+            typing: false,
+          });
+        }
+      });
+
+    channelRef.current = channel;
 
     return () => {
       supabase.removeChannel(channel);
+      channelRef.current = null;
     };
-  }, [groupId]);
+  }, [groupId, currentUserId, currentUserName]);
 
-  // Polling fallback
+  // Polling fallback (30s — realtime is primary, polling is safety net)
   useEffect(() => {
-    const pollInterval = setInterval(fetchMessages, 5000);
+    const pollInterval = setInterval(fetchMessages, 30000);
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") fetchMessages();
     };
@@ -259,10 +300,41 @@ export function GroupChat({
     };
   }, [fetchMessages]);
 
+  // Track scroll position for jump-to-bottom button
   useEffect(() => {
-    if (prevMessageCountRef.current > 0 && messages.length > prevMessageCountRef.current) {
-      scrollToBottom();
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    const handleScroll = () => {
+      const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 100;
+      setIsScrolledUp(!nearBottom);
+      if (nearBottom) setNewMsgCount(0);
+    };
+    el.addEventListener("scroll", handleScroll);
+    return () => el.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  useEffect(() => {
+    if (messages.length === 0) return;
+
+    if (!hasInitialScrolledRef.current) {
+      messagesEndRef.current?.scrollIntoView();
+      hasInitialScrolledRef.current = true;
+      prevMessageCountRef.current = messages.length;
+      return;
     }
+
+    if (messages.length > prevMessageCountRef.current) {
+      const el = scrollContainerRef.current;
+      if (el) {
+        const isNearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 100;
+        if (isNearBottom) {
+          scrollToBottom();
+        } else {
+          setNewMsgCount((c) => c + (messages.length - prevMessageCountRef.current));
+        }
+      }
+    }
+
     prevMessageCountRef.current = messages.length;
   }, [messages]);
 
@@ -281,6 +353,23 @@ export function GroupChat({
     } else {
       setMentionSearch(null);
     }
+
+    // Typing indicator via presence
+    if (channelRef.current) {
+      channelRef.current.track({
+        userId: currentUserId,
+        userName: currentUserName ?? "",
+        typing: true,
+      });
+      if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
+      typingTimeoutRef.current = setTimeout(() => {
+        channelRef.current?.track({
+          userId: currentUserId,
+          userName: currentUserName ?? "",
+          typing: false,
+        });
+      }, 2000);
+    }
   };
 
   const filteredMembers = mentionSearch !== null
@@ -295,12 +384,17 @@ export function GroupChat({
 
   const handleMentionSelect = (member: Member) => {
     const name = member.profiles?.full_name ?? "";
-    // Replace the @partial with @FullName
     const updated = newMessage.replace(/@([^\s]*)$/, `@${name} `);
     setNewMessage(updated);
     setMentionSearch(null);
     setMentionedUserIds((prev) => new Set([...prev, member.user_id]));
     inputRef.current?.focus();
+  };
+
+  const handleScrollToBottom = () => {
+    scrollToBottom();
+    setNewMsgCount(0);
+    setIsScrolledUp(false);
   };
 
   const handleSend = async (e: React.FormEvent) => {
@@ -313,6 +407,14 @@ export function GroupChat({
     setMentionSearch(null);
     setMentionedUserIds(new Set());
     setSending(true);
+
+    // Clear typing indicator immediately on send
+    if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
+    channelRef.current?.track({
+      userId: currentUserId,
+      userName: currentUserName ?? "",
+      typing: false,
+    });
 
     const tempId = `temp-${Date.now()}`;
     const optimisticMsg: Message = {
@@ -353,7 +455,7 @@ export function GroupChat({
     async (messageId: string) => {
       if (!editContent.trim()) return;
       try {
-        await editGroupMessage(messageId, editContent.trim());
+        await editGroupMessage(messageId, editContent.trim(), groupId);
         setMessages((prev) =>
           prev.map((m) =>
             m.id === messageId ? { ...m, content: editContent.trim(), is_edited: true } : m
@@ -365,19 +467,19 @@ export function GroupChat({
         toast.error(err instanceof Error ? err.message : "Failed to edit message");
       }
     },
-    [editContent]
+    [editContent, groupId]
   );
 
   const handleDelete = useCallback(async (messageId: string) => {
     try {
-      await deleteGroupMessage(messageId);
+      await deleteGroupMessage(messageId, groupId);
       setMessages((prev) =>
         prev.map((m) => (m.id === messageId ? { ...m, content: "", is_deleted: true } : m))
       );
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to delete message");
     }
-  }, []);
+  }, [groupId]);
 
   const handleReaction = useCallback(
     async (messageId: string, emoji: string) => {
@@ -444,6 +546,7 @@ export function GroupChat({
 
   const isAnyPickerOpen = emojiPickerMsgId !== null || showInputEmoji;
   const showMentionMenu = mentionSearch !== null && filteredMembers.length > 0;
+  const charsLeft = 2000 - newMessage.length;
 
   return (
     <div className="flex flex-col h-full relative">
@@ -461,24 +564,48 @@ export function GroupChat({
       {/* Messages */}
       <div
         ref={scrollContainerRef}
-        className="flex-1 overflow-y-auto space-y-3 p-4 min-h-0"
+        className="flex-1 overflow-y-auto p-4 min-h-0 chat-texture"
       >
         {messages.length === 0 && (
           <p className="text-sm text-muted-foreground text-center py-8">
             No messages yet. Say hello to the group!
           </p>
         )}
-        {messages.map((msg) => {
+        {messages.map((msg, index) => {
+          const prevMsg = messages[index - 1];
+          const isGrouped =
+            !msg.is_system_message &&
+            !!prevMsg &&
+            !prevMsg.is_system_message &&
+            prevMsg.user_id === msg.user_id &&
+            !msg.id.startsWith("temp-") &&
+            new Date(msg.created_at).getTime() -
+              new Date(prevMsg.created_at).getTime() <
+              2 * 60 * 1000;
+
+          const msgDate = new Date(msg.created_at).toDateString();
+          const prevMsgDate = prevMsg ? new Date(prevMsg.created_at).toDateString() : null;
+          const showDateSeparator = msgDate !== prevMsgDate;
+
           if (msg.is_system_message) {
             return (
-              <div key={msg.id} className="flex justify-center my-2">
-                <div className="bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-lg px-4 py-2 max-w-[85%] text-center">
-                  <p className="text-xs text-amber-800 dark:text-amber-200 whitespace-pre-line">
-                    {msg.content}
-                  </p>
-                  <p className="text-[10px] text-amber-600 dark:text-amber-400 mt-1">
-                    {formatDistanceToNow(new Date(msg.created_at), { addSuffix: true })}
-                  </p>
+              <div key={msg.id}>
+                {showDateSeparator && (
+                  <div className="flex items-center gap-3 my-4">
+                    <div className="flex-1 h-px bg-border" />
+                    <span className="text-[10px] text-muted-foreground uppercase tracking-wide">{formatDateLabel(msg.created_at)}</span>
+                    <div className="flex-1 h-px bg-border" />
+                  </div>
+                )}
+                <div className="flex justify-center my-3">
+                  <div className="bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-lg px-4 py-2 max-w-[85%] text-center">
+                    <p className="text-xs text-amber-800 dark:text-amber-200 whitespace-pre-line">
+                      {msg.content}
+                    </p>
+                    <p className="text-[10px] text-amber-600 dark:text-amber-400 mt-1">
+                      {formatDistanceToNow(new Date(msg.created_at), { addSuffix: true })}
+                    </p>
+                  </div>
                 </div>
               </div>
             );
@@ -488,22 +615,32 @@ export function GroupChat({
           const name = msg.profiles?.full_name ?? "Unknown";
           const isEditing = editingId === msg.id;
           const grouped = getGroupedReactions(msg.id);
+          const isSending = msg.id.startsWith("temp-");
 
           return (
+            <div key={msg.id}>
+              {showDateSeparator && (
+                <div className="flex items-center gap-3 my-4">
+                  <div className="flex-1 h-px bg-border" />
+                  <span className="text-[10px] text-muted-foreground uppercase tracking-wide">{formatDateLabel(msg.created_at)}</span>
+                  <div className="flex-1 h-px bg-border" />
+                </div>
+              )}
             <div
-              key={msg.id}
-              className={`flex gap-2 ${isOwn ? "flex-row-reverse" : ""}`}
+              className={`flex gap-2 ${isOwn ? "flex-row-reverse" : ""} ${isGrouped ? "mt-0.5" : "mt-3"} ${isSending ? "opacity-60" : ""}`}
               onMouseEnter={() => setHoveredId(msg.id)}
               onMouseLeave={() => setHoveredId(null)}
             >
               {!isOwn && (
-                <Avatar className="h-7 w-7 shrink-0 mt-1">
-                  <AvatarImage src={msg.profiles?.avatar_url ?? undefined} />
-                  <AvatarFallback className="text-[10px]">{getInitials(name)}</AvatarFallback>
-                </Avatar>
+                isGrouped
+                  ? <div className="w-7 shrink-0" />
+                  : <Avatar className="h-7 w-7 shrink-0 mt-1">
+                      <AvatarImage src={msg.profiles?.avatar_url ?? undefined} />
+                      <AvatarFallback className="text-[10px]">{getInitials(name)}</AvatarFallback>
+                    </Avatar>
               )}
               <div className={`max-w-[75%] relative ${isOwn ? "items-end" : "items-start"}`}>
-                {!isOwn && (
+                {!isOwn && !isGrouped && (
                   <p className="text-xs text-muted-foreground mb-0.5">{name}</p>
                 )}
 
@@ -606,8 +743,8 @@ export function GroupChat({
                   </div>
                 ) : (
                   <div
-                    className={`rounded-lg px-3 py-1.5 text-sm ${
-                      isOwn ? "bg-primary text-primary-foreground" : "bg-muted"
+                    className={`rounded-lg px-3 py-1.5 text-sm whitespace-pre-wrap break-words ${
+                      isOwn ? "bg-emerald-600 text-white dark:bg-emerald-600" : "bg-muted"
                     }`}
                   >
                     {renderContent(msg.content, currentUserName)}
@@ -634,8 +771,8 @@ export function GroupChat({
                   </div>
                 )}
 
-                {/* Timestamp */}
-                {!isEditing && (
+                {/* Timestamp — hidden on grouped messages unless hovered */}
+                {!isEditing && (!isGrouped || hoveredId === msg.id) && (
                   <p className="text-[10px] text-muted-foreground mt-0.5">
                     {formatDistanceToNow(new Date(msg.created_at), { addSuffix: true })}
                     {msg.is_edited && !msg.is_deleted && (
@@ -645,10 +782,39 @@ export function GroupChat({
                 )}
               </div>
             </div>
+            </div>
           );
         })}
         <div ref={messagesEndRef} />
       </div>
+
+      {/* Jump to bottom button */}
+      {isScrolledUp && (
+        <div className="absolute bottom-[5.5rem] left-0 right-0 flex justify-center z-20 pointer-events-none">
+          <button
+            onClick={handleScrollToBottom}
+            className="pointer-events-auto flex items-center gap-1.5 bg-emerald-600 text-white text-xs px-3 py-1.5 rounded-full shadow-lg hover:bg-emerald-700 transition-colors"
+          >
+            <ChevronDown className="h-3.5 w-3.5" />
+            {newMsgCount > 0
+              ? `${newMsgCount} new ${newMsgCount === 1 ? "message" : "messages"}`
+              : "Scroll to bottom"}
+          </button>
+        </div>
+      )}
+
+      {/* Typing indicator */}
+      {typingUsers.length > 0 && (
+        <div className="px-4 py-1">
+          <p className="text-xs text-muted-foreground italic">
+            {typingUsers.length === 1
+              ? `${typingUsers[0]} is typing...`
+              : typingUsers.length === 2
+              ? `${typingUsers[0]} and ${typingUsers[1]} are typing...`
+              : "Several people are typing..."}
+          </p>
+        </div>
+      )}
 
       {/* Input */}
       <div className="p-4 border-t bg-background relative">
@@ -690,30 +856,46 @@ export function GroupChat({
             />
           </div>
         )}
-        <form onSubmit={handleSend} className="flex gap-2 items-center">
+        <form onSubmit={handleSend} className="flex gap-2 items-end">
           <Button
             type="button"
             variant="ghost"
             size="icon"
-            className="shrink-0"
+            className="shrink-0 mb-0.5"
             onClick={() => setShowInputEmoji(!showInputEmoji)}
           >
             <Smile className="h-5 w-5" />
           </Button>
-          <Input
+          <Textarea
             ref={inputRef}
             value={newMessage}
             onChange={(e) => handleInputChange(e.target.value)}
             onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                e.currentTarget.form?.requestSubmit();
+              }
               if (e.key === "Escape") setMentionSearch(null);
             }}
             placeholder="Message the group... (type @ to mention)"
             disabled={sending}
+            maxLength={2000}
+            rows={1}
+            className="min-h-[40px] max-h-[120px] resize-none py-2.5 overflow-y-auto"
           />
-          <Button type="submit" size="icon" disabled={sending || !newMessage.trim()}>
+          <Button type="submit" size="icon" className="shrink-0 mb-0.5" disabled={sending || !newMessage.trim()}>
             <Send className="h-4 w-4" />
           </Button>
         </form>
+        {charsLeft <= 400 && (
+          <p
+            className={`text-[10px] text-right mt-1 ${
+              charsLeft <= 100 ? "text-destructive" : "text-muted-foreground"
+            }`}
+          >
+            {charsLeft} remaining
+          </p>
+        )}
       </div>
     </div>
   );

--- a/src/components/messages/chat-window.tsx
+++ b/src/components/messages/chat-window.tsx
@@ -11,8 +11,9 @@ import {
 } from "@/lib/actions/messages";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Send, ArrowLeft, Pencil, Trash2, Smile, X, Check } from "lucide-react";
+import { Send, ArrowLeft, Pencil, Trash2, Smile, X, Check, ChevronDown } from "lucide-react";
 import { toast } from "sonner";
 import { formatDistanceToNow } from "date-fns";
 import Link from "next/link";
@@ -71,9 +72,19 @@ export function ChatWindow({
   const [reactions, setReactions] = useState<Record<string, Reaction[]>>({});
   const [emojiPickerMsgId, setEmojiPickerMsgId] = useState<string | null>(null);
   const [showInputEmoji, setShowInputEmoji] = useState(false);
+  const [otherUserTyping, setOtherUserTyping] = useState(false);
+  const [isScrolledUp, setIsScrolledUp] = useState(false);
+  const [newMsgCount, setNewMsgCount] = useState(0);
+
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
   const editInputRef = useRef<HTMLInputElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const prevMessageCountRef = useRef<number>(0);
+  const hasInitialScrolledRef = useRef(false);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const channelRef = useRef<any>(null);
+  const typingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const fetchMessages = useCallback(async () => {
     const supabase = createClient();
@@ -128,7 +139,7 @@ export function ChatWindow({
     markDirectMessagesAsRead(otherUserId).catch(() => {});
   }, [fetchMessages, otherUserId]);
 
-  // Realtime subscription
+  // Realtime subscription + presence for typing indicator
   useEffect(() => {
     const supabase = createClient();
 
@@ -234,16 +245,33 @@ export function ChatWindow({
           });
         }
       )
-      .subscribe();
+      .on("presence", { event: "sync" }, () => {
+        const state = channel.presenceState<{
+          userId: string;
+          typing: boolean;
+        }>();
+        const isOtherTyping = Object.values(state)
+          .flat()
+          .some((p) => p.userId === otherUserId && p.typing);
+        setOtherUserTyping(isOtherTyping);
+      })
+      .subscribe(async (status: string) => {
+        if (status === "SUBSCRIBED") {
+          await channel.track({ userId: currentUserId, typing: false });
+        }
+      });
+
+    channelRef.current = channel;
 
     return () => {
       supabase.removeChannel(channel);
+      channelRef.current = null;
     };
   }, [currentUserId, otherUserId]);
 
-  // Polling fallback + visibility refetch (ensures messages update even if realtime fails)
+  // Polling fallback + visibility refetch (30s — realtime is primary, polling is safety net)
   useEffect(() => {
-    const pollInterval = setInterval(fetchMessages, 5000);
+    const pollInterval = setInterval(fetchMessages, 30000);
 
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") {
@@ -258,9 +286,43 @@ export function ChatWindow({
     };
   }, [fetchMessages]);
 
-  // Auto-scroll
+  // Track scroll position for jump-to-bottom button
   useEffect(() => {
-    scrollToBottom();
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    const handleScroll = () => {
+      const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 100;
+      setIsScrolledUp(!nearBottom);
+      if (nearBottom) setNewMsgCount(0);
+    };
+    el.addEventListener("scroll", handleScroll);
+    return () => el.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  // Auto-scroll: instant jump on initial load, smart scroll for new messages
+  useEffect(() => {
+    if (messages.length === 0) return;
+
+    if (!hasInitialScrolledRef.current) {
+      messagesEndRef.current?.scrollIntoView();
+      hasInitialScrolledRef.current = true;
+      prevMessageCountRef.current = messages.length;
+      return;
+    }
+
+    if (messages.length > prevMessageCountRef.current) {
+      const el = scrollContainerRef.current;
+      if (el) {
+        const isNearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 100;
+        if (isNearBottom) {
+          scrollToBottom();
+        } else {
+          setNewMsgCount((c) => c + (messages.length - prevMessageCountRef.current));
+        }
+      }
+    }
+
+    prevMessageCountRef.current = messages.length;
   }, [messages]);
 
   // Focus edit input
@@ -270,6 +332,12 @@ export function ChatWindow({
     }
   }, [editingId]);
 
+  const handleScrollToBottom = () => {
+    scrollToBottom();
+    setNewMsgCount(0);
+    setIsScrolledUp(false);
+  };
+
   const handleSend = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!newMessage.trim() || sending) return;
@@ -277,6 +345,10 @@ export function ChatWindow({
     const content = newMessage.trim();
     setNewMessage("");
     setSending(true);
+
+    // Clear typing indicator immediately on send
+    if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
+    channelRef.current?.track({ userId: currentUserId, typing: false });
 
     const tempId = `temp-${Date.now()}`;
     const optimisticMsg: Message = {
@@ -360,7 +432,6 @@ export function ChatWindow({
 
   const handleReaction = useCallback(
     async (messageId: string, emoji: string) => {
-      // Optimistic update
       const tempReaction: Reaction = {
         id: `temp-${Date.now()}`,
         user_id: currentUserId,
@@ -375,7 +446,6 @@ export function ChatWindow({
       );
 
       if (userExisting) {
-        // Optimistically remove
         setReactions((prev) => {
           const updated = (prev[messageId] || []).filter(
             (r) => r.id !== userExisting.id
@@ -388,7 +458,6 @@ export function ChatWindow({
           return { ...prev, [messageId]: updated };
         });
       } else {
-        // Optimistically add
         setReactions((prev) => ({
           ...prev,
           [messageId]: [...(prev[messageId] || []), tempReaction],
@@ -400,7 +469,6 @@ export function ChatWindow({
       try {
         await toggleReaction("direct", messageId, emoji);
       } catch (err) {
-        // Revert on error
         if (userExisting) {
           setReactions((prev) => ({
             ...prev,
@@ -434,6 +502,16 @@ export function ChatWindow({
       .join("")
       .toUpperCase();
 
+  const formatDateLabel = (dateStr: string): string => {
+    const date = new Date(dateStr);
+    const today = new Date();
+    const yesterday = new Date();
+    yesterday.setDate(today.getDate() - 1);
+    if (date.toDateString() === today.toDateString()) return "Today";
+    if (date.toDateString() === yesterday.toDateString()) return "Yesterday";
+    return date.toLocaleDateString(undefined, { weekday: "long", month: "long", day: "numeric" });
+  };
+
   const getGroupedReactions = (messageId: string) => {
     const msgReactions = reactions[messageId] || [];
     const grouped: Record<string, { emoji: string; count: number; userReacted: boolean }> = {};
@@ -447,11 +525,11 @@ export function ChatWindow({
     return Object.values(grouped);
   };
 
-  // Determine which picker is open (message reaction or input)
   const isAnyPickerOpen = emojiPickerMsgId !== null || showInputEmoji;
+  const charsLeft = 2000 - newMessage.length;
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full relative">
       {/* Header */}
       <div className="flex items-center gap-3 p-4 border-b">
         {showBackButton && (
@@ -467,11 +545,18 @@ export function ChatWindow({
             {getInitials(otherUserName)}
           </AvatarFallback>
         </Avatar>
-        <p className="font-medium text-sm">{otherUserName}</p>
+        <div>
+          <p className="font-medium text-sm leading-tight">{otherUserName}</p>
+          {otherUserTyping && (
+            <p className="text-[10px] text-emerald-600 dark:text-emerald-400 italic">
+              typing...
+            </p>
+          )}
+        </div>
       </div>
 
       {/* Messages */}
-      <div className="flex-1 overflow-y-auto p-4 space-y-3">
+      <div ref={scrollContainerRef} className="flex-1 overflow-y-auto p-4 space-y-0 chat-texture">
         {loading && (
           <p className="text-sm text-muted-foreground text-center py-8">
             Loading messages...
@@ -482,15 +567,36 @@ export function ChatWindow({
             No messages yet. Say hello!
           </p>
         )}
-        {messages.map((msg) => {
+        {messages.map((msg, index) => {
+          const prevMsg = messages[index - 1];
+          const isGrouped =
+            !!prevMsg &&
+            prevMsg.sender_id === msg.sender_id &&
+            !msg.id.startsWith("temp-") &&
+            new Date(msg.created_at).getTime() -
+              new Date(prevMsg.created_at).getTime() <
+              2 * 60 * 1000;
+
+          const msgDate = new Date(msg.created_at).toDateString();
+          const prevMsgDate = prevMsg ? new Date(prevMsg.created_at).toDateString() : null;
+          const showDateSeparator = msgDate !== prevMsgDate;
+
           const isOwn = msg.sender_id === currentUserId;
           const isEditing = editingId === msg.id;
           const grouped = getGroupedReactions(msg.id);
+          const isSending = msg.id.startsWith("temp-");
 
           return (
+            <div key={msg.id}>
+              {showDateSeparator && (
+                <div className="flex items-center gap-3 my-4">
+                  <div className="flex-1 h-px bg-border" />
+                  <span className="text-[10px] text-muted-foreground uppercase tracking-wide">{formatDateLabel(msg.created_at)}</span>
+                  <div className="flex-1 h-px bg-border" />
+                </div>
+              )}
             <div
-              key={msg.id}
-              className={`flex ${isOwn ? "justify-end" : "justify-start"}`}
+              className={`flex ${isOwn ? "justify-end" : "justify-start"} ${isGrouped ? "mt-0.5" : "mt-3"} ${isSending ? "opacity-60" : ""}`}
               onMouseEnter={() => setHoveredId(msg.id)}
               onMouseLeave={() => setHoveredId(null)}
             >
@@ -543,21 +649,21 @@ export function ChatWindow({
                     </div>
                   )}
 
-                {/* Message-level emoji picker (rendered only for active message) */}
+                {/* Message-level emoji picker */}
                 {emojiPickerMsgId === msg.id && (
                   <div
                     className={`absolute bottom-full mb-1 z-50 ${
                       isOwn ? "right-0" : "left-0"
                     }`}
                   >
-                      <EmojiPicker
-                        onEmojiSelect={(emoji: { native: string }) =>
-                          handleReaction(msg.id, emoji.native)
-                        }
-                        theme="auto"
-                        previewPosition="none"
-                        skinTonePosition="none"
-                      />
+                    <EmojiPicker
+                      onEmojiSelect={(emoji: { native: string }) =>
+                        handleReaction(msg.id, emoji.native)
+                      }
+                      theme="auto"
+                      previewPosition="none"
+                      skinTonePosition="none"
+                    />
                   </div>
                 )}
 
@@ -603,9 +709,9 @@ export function ChatWindow({
                   </div>
                 ) : (
                   <div
-                    className={`rounded-lg px-3 py-1.5 text-sm ${
+                    className={`rounded-lg px-3 py-1.5 text-sm whitespace-pre-wrap break-words ${
                       isOwn
-                        ? "bg-primary text-primary-foreground"
+                        ? "bg-emerald-600 text-white dark:bg-emerald-600"
                         : "bg-muted"
                     }`}
                   >
@@ -633,8 +739,8 @@ export function ChatWindow({
                   </div>
                 )}
 
-                {/* Timestamp + edited label */}
-                {!isEditing && (
+                {/* Timestamp — hidden on grouped messages unless hovered */}
+                {!isEditing && (!isGrouped || hoveredId === msg.id) && (
                   <p
                     className={`text-[10px] text-muted-foreground mt-0.5 ${
                       isOwn ? "text-right" : ""
@@ -650,10 +756,26 @@ export function ChatWindow({
                 )}
               </div>
             </div>
+            </div>
           );
         })}
         <div ref={messagesEndRef} />
       </div>
+
+      {/* Jump to bottom button */}
+      {isScrolledUp && (
+        <div className="absolute bottom-[5rem] left-0 right-0 flex justify-center z-20 pointer-events-none">
+          <button
+            onClick={handleScrollToBottom}
+            className="pointer-events-auto flex items-center gap-1.5 bg-emerald-600 text-white text-xs px-3 py-1.5 rounded-full shadow-lg hover:bg-emerald-700 transition-colors"
+          >
+            <ChevronDown className="h-3.5 w-3.5" />
+            {newMsgCount > 0
+              ? `${newMsgCount} new ${newMsgCount === 1 ? "message" : "messages"}`
+              : "Scroll to bottom"}
+          </button>
+        </div>
+      )}
 
       {/* Dismiss overlay when emoji picker is open */}
       {isAnyPickerOpen && (
@@ -668,46 +790,74 @@ export function ChatWindow({
 
       {/* Input */}
       <div className="p-4 border-t relative">
-        {/* Input emoji picker - single instance, rendered only when open */}
         {showInputEmoji && (
           <div className="absolute bottom-full mb-2 left-4 z-50">
-              <EmojiPicker
-                onEmojiSelect={(emoji: { native: string }) => {
-                  setNewMessage((prev) => prev + emoji.native);
-                  setShowInputEmoji(false);
-                  inputRef.current?.focus();
-                }}
-                theme="auto"
-                previewPosition="none"
-                skinTonePosition="none"
-              />
+            <EmojiPicker
+              onEmojiSelect={(emoji: { native: string }) => {
+                setNewMessage((prev) => prev + emoji.native);
+                setShowInputEmoji(false);
+                inputRef.current?.focus();
+              }}
+              theme="auto"
+              previewPosition="none"
+              skinTonePosition="none"
+            />
           </div>
         )}
-        <form onSubmit={handleSend} className="flex gap-2 items-center">
+        <form onSubmit={handleSend} className="flex gap-2 items-end">
           <Button
             type="button"
             variant="ghost"
             size="icon"
-            className="shrink-0"
+            className="shrink-0 mb-0.5"
             onClick={() => setShowInputEmoji(!showInputEmoji)}
           >
             <Smile className="h-5 w-5" />
           </Button>
-          <Input
+          <Textarea
             ref={inputRef}
             value={newMessage}
-            onChange={(e) => setNewMessage(e.target.value)}
+            onChange={(e) => {
+              const value = e.target.value;
+              setNewMessage(value);
+              if (channelRef.current) {
+                channelRef.current.track({ userId: currentUserId, typing: true });
+                if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
+                typingTimeoutRef.current = setTimeout(() => {
+                  channelRef.current?.track({ userId: currentUserId, typing: false });
+                }, 2000);
+              }
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                e.currentTarget.form?.requestSubmit();
+              }
+            }}
             placeholder="Type a message..."
             disabled={sending}
+            maxLength={2000}
+            rows={1}
+            className="min-h-[40px] max-h-[120px] resize-none py-2.5 overflow-y-auto"
           />
           <Button
             type="submit"
             size="icon"
+            className="shrink-0 mb-0.5"
             disabled={sending || !newMessage.trim()}
           >
             <Send className="h-4 w-4" />
           </Button>
         </form>
+        {charsLeft <= 400 && (
+          <p
+            className={`text-[10px] text-right mt-1 ${
+              charsLeft <= 100 ? "text-destructive" : "text-muted-foreground"
+            }`}
+          >
+            {charsLeft} remaining
+          </p>
+        )}
       </div>
     </div>
   );

--- a/src/components/sessions/session-chat.tsx
+++ b/src/components/sessions/session-chat.tsx
@@ -12,7 +12,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { MessageCircle, Send, Pencil, Trash2, Smile, X, Check } from "lucide-react";
+import { MessageCircle, Send, Pencil, Trash2, Smile, X, Check, ChevronDown } from "lucide-react";
 import { toast } from "sonner";
 import { formatDistanceToNow } from "date-fns";
 import dynamic from "next/dynamic";
@@ -64,11 +64,19 @@ export function SessionChat({ sessionId, currentUserId }: SessionChatProps) {
   const [reactions, setReactions] = useState<Record<string, Reaction[]>>({});
   const [emojiPickerMsgId, setEmojiPickerMsgId] = useState<string | null>(null);
   const [showInputEmoji, setShowInputEmoji] = useState(false);
+  const [typingCount, setTypingCount] = useState(0);
+  const [isScrolledUp, setIsScrolledUp] = useState(false);
+  const [newMsgCount, setNewMsgCount] = useState(0);
+
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const editInputRef = useRef<HTMLInputElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const prevMessageCountRef = useRef<number>(0);
+  const hasInitialScrolledRef = useRef(false);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const channelRef = useRef<any>(null);
+  const typingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const fetchMessages = useCallback(async () => {
     const supabase = createClient();
@@ -120,7 +128,7 @@ export function SessionChat({ sessionId, currentUserId }: SessionChatProps) {
     fetchMessages();
   }, [fetchMessages]);
 
-  // Subscribe to realtime messages
+  // Subscribe to realtime messages + presence for typing indicator
   useEffect(() => {
     const supabase = createClient();
 
@@ -219,16 +227,33 @@ export function SessionChat({ sessionId, currentUserId }: SessionChatProps) {
           });
         }
       )
-      .subscribe();
+      .on("presence", { event: "sync" }, () => {
+        const state = channel.presenceState<{
+          userId: string;
+          typing: boolean;
+        }>();
+        const count = Object.values(state)
+          .flat()
+          .filter((p) => p.typing && p.userId !== currentUserId).length;
+        setTypingCount(count);
+      })
+      .subscribe(async (status: string) => {
+        if (status === "SUBSCRIBED") {
+          await channel.track({ userId: currentUserId, typing: false });
+        }
+      });
+
+    channelRef.current = channel;
 
     return () => {
       supabase.removeChannel(channel);
+      channelRef.current = null;
     };
-  }, [sessionId]);
+  }, [sessionId, currentUserId]);
 
-  // Polling fallback + visibility refetch (ensures messages update even if realtime fails)
+  // Polling fallback + visibility refetch (30s — realtime is primary, polling is safety net)
   useEffect(() => {
-    const pollInterval = setInterval(fetchMessages, 5000);
+    const pollInterval = setInterval(fetchMessages, 30000);
 
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") {
@@ -243,11 +268,41 @@ export function SessionChat({ sessionId, currentUserId }: SessionChatProps) {
     };
   }, [fetchMessages]);
 
+  // Track scroll position for jump-to-bottom button
   useEffect(() => {
-    // Only auto-scroll when new messages arrive, not on initial load
-    if (prevMessageCountRef.current > 0 && messages.length > prevMessageCountRef.current) {
-      scrollToBottom();
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    const handleScroll = () => {
+      const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 100;
+      setIsScrolledUp(!nearBottom);
+      if (nearBottom) setNewMsgCount(0);
+    };
+    el.addEventListener("scroll", handleScroll);
+    return () => el.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  useEffect(() => {
+    if (messages.length === 0) return;
+
+    if (!hasInitialScrolledRef.current) {
+      messagesEndRef.current?.scrollIntoView();
+      hasInitialScrolledRef.current = true;
+      prevMessageCountRef.current = messages.length;
+      return;
     }
+
+    if (messages.length > prevMessageCountRef.current) {
+      const el = scrollContainerRef.current;
+      if (el) {
+        const isNearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 100;
+        if (isNearBottom) {
+          scrollToBottom();
+        } else {
+          setNewMsgCount((c) => c + (messages.length - prevMessageCountRef.current));
+        }
+      }
+    }
+
     prevMessageCountRef.current = messages.length;
   }, [messages]);
 
@@ -257,6 +312,12 @@ export function SessionChat({ sessionId, currentUserId }: SessionChatProps) {
     }
   }, [editingId]);
 
+  const handleScrollToBottom = () => {
+    scrollToBottom();
+    setNewMsgCount(0);
+    setIsScrolledUp(false);
+  };
+
   const handleSend = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!newMessage.trim() || sending) return;
@@ -264,6 +325,10 @@ export function SessionChat({ sessionId, currentUserId }: SessionChatProps) {
     const content = newMessage.trim();
     setNewMessage("");
     setSending(true);
+
+    // Clear typing indicator immediately on send
+    if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
+    channelRef.current?.track({ userId: currentUserId, typing: false });
 
     const tempId = `temp-${Date.now()}`;
     const optimisticMsg: Message = {
@@ -308,7 +373,7 @@ export function SessionChat({ sessionId, currentUserId }: SessionChatProps) {
     async (messageId: string) => {
       if (!editContent.trim()) return;
       try {
-        await editSessionMessage(messageId, editContent.trim());
+        await editSessionMessage(messageId, editContent.trim(), sessionId);
         setMessages((prev) =>
           prev.map((m) =>
             m.id === messageId
@@ -324,12 +389,12 @@ export function SessionChat({ sessionId, currentUserId }: SessionChatProps) {
         );
       }
     },
-    [editContent]
+    [editContent, sessionId]
   );
 
   const handleDelete = useCallback(async (messageId: string) => {
     try {
-      await deleteSessionMessage(messageId);
+      await deleteSessionMessage(messageId, sessionId);
       setMessages((prev) =>
         prev.map((m) =>
           m.id === messageId
@@ -342,11 +407,10 @@ export function SessionChat({ sessionId, currentUserId }: SessionChatProps) {
         err instanceof Error ? err.message : "Failed to delete message"
       );
     }
-  }, []);
+  }, [sessionId]);
 
   const handleReaction = useCallback(
     async (messageId: string, emoji: string) => {
-      // Optimistic update
       const tempReaction: Reaction = {
         id: `temp-${Date.now()}`,
         user_id: currentUserId,
@@ -434,6 +498,7 @@ export function SessionChat({ sessionId, currentUserId }: SessionChatProps) {
   };
 
   const isAnyPickerOpen = emojiPickerMsgId !== null || showInputEmoji;
+  const charsLeft = 2000 - newMessage.length;
 
   return (
     <Card>
@@ -456,122 +521,135 @@ export function SessionChat({ sessionId, currentUserId }: SessionChatProps) {
         )}
 
         {/* Messages */}
-        <div
-          ref={scrollContainerRef}
-          className="h-80 overflow-y-auto space-y-3 mb-4 p-3 rounded-md border bg-muted/30"
-        >
-          {messages.length === 0 && (
-            <p className="text-sm text-muted-foreground text-center py-8">
-              No messages yet. Start the conversation!
-            </p>
-          )}
-          {messages.map((msg) => {
-            // System messages render differently
-            if (msg.is_system_message) {
-              return (
-                <div key={msg.id} className="flex justify-center my-2">
-                  <div className="bg-amber-50 border border-amber-200 rounded-lg px-4 py-2 max-w-[85%] text-center">
-                    <p className="text-xs text-amber-800 whitespace-pre-line">
-                      {msg.content}
-                    </p>
-                    <p className="text-[10px] text-amber-600 mt-1">
-                      {formatDistanceToNow(new Date(msg.created_at), {
-                        addSuffix: true,
-                      })}
-                    </p>
+        <div className="relative">
+          <div
+            ref={scrollContainerRef}
+            className="h-80 overflow-y-auto space-y-0 mb-4 p-3 rounded-md border bg-muted/30 chat-texture"
+          >
+            {messages.length === 0 && (
+              <p className="text-sm text-muted-foreground text-center py-8">
+                No messages yet. Start the conversation!
+              </p>
+            )}
+            {messages.map((msg, index) => {
+              const prevMsg = messages[index - 1];
+              const isGrouped =
+                !msg.is_system_message &&
+                !!prevMsg &&
+                !prevMsg.is_system_message &&
+                prevMsg.user_id === msg.user_id &&
+                !msg.id.startsWith("temp-") &&
+                new Date(msg.created_at).getTime() -
+                  new Date(prevMsg.created_at).getTime() <
+                  2 * 60 * 1000;
+
+              // System messages render differently
+              if (msg.is_system_message) {
+                return (
+                  <div key={msg.id} className="flex justify-center my-3">
+                    <div className="bg-amber-50 border border-amber-200 rounded-lg px-4 py-2 max-w-[85%] text-center">
+                      <p className="text-xs text-amber-800 whitespace-pre-line">
+                        {msg.content}
+                      </p>
+                      <p className="text-[10px] text-amber-600 mt-1">
+                        {formatDistanceToNow(new Date(msg.created_at), {
+                          addSuffix: true,
+                        })}
+                      </p>
+                    </div>
                   </div>
-                </div>
-              );
-            }
+                );
+              }
 
-            const isOwn = msg.user_id === currentUserId;
-            const name = msg.profiles?.full_name ?? "Unknown";
-            const isEditing = editingId === msg.id;
-            const grouped = getGroupedReactions(msg.id);
+              const isOwn = msg.user_id === currentUserId;
+              const name = msg.profiles?.full_name ?? "Unknown";
+              const isEditing = editingId === msg.id;
+              const grouped = getGroupedReactions(msg.id);
+              const isSending = msg.id.startsWith("temp-");
 
-            return (
-              <div
-                key={msg.id}
-                className={`flex gap-2 ${isOwn ? "flex-row-reverse" : ""}`}
-                onMouseEnter={() => setHoveredId(msg.id)}
-                onMouseLeave={() => setHoveredId(null)}
-              >
-                {!isOwn && (
-                  <Avatar className="h-7 w-7 shrink-0">
-                    <AvatarImage
-                      src={msg.profiles?.avatar_url ?? undefined}
-                    />
-                    <AvatarFallback className="text-[10px]">
-                      {getInitials(name)}
-                    </AvatarFallback>
-                  </Avatar>
-                )}
+              return (
                 <div
-                  className={`max-w-[75%] relative ${
-                    isOwn ? "items-end" : "items-start"
-                  }`}
+                  key={msg.id}
+                  className={`flex gap-2 ${isOwn ? "flex-row-reverse" : ""} ${isGrouped ? "mt-0.5" : "mt-3"} ${isSending ? "opacity-60" : ""}`}
+                  onMouseEnter={() => setHoveredId(msg.id)}
+                  onMouseLeave={() => setHoveredId(null)}
                 >
                   {!isOwn && (
-                    <p className="text-xs text-muted-foreground mb-0.5">
-                      {name}
-                    </p>
+                    isGrouped
+                      ? <div className="w-7 shrink-0" />
+                      : <Avatar className="h-7 w-7 shrink-0">
+                          <AvatarImage src={msg.profiles?.avatar_url ?? undefined} />
+                          <AvatarFallback className="text-[10px]">
+                            {getInitials(name)}
+                          </AvatarFallback>
+                        </Avatar>
                   )}
-
-                  {/* Action buttons */}
-                  {hoveredId === msg.id &&
-                    !isEditing &&
-                    !msg.is_deleted &&
-                    !msg.id.startsWith("temp-") && (
-                      <div
-                        className={`absolute -top-8 ${
-                          isOwn ? "right-0" : "left-0"
-                        } flex items-center gap-0.5 bg-background border rounded-md shadow-sm p-0.5 z-10`}
-                      >
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-7 w-7"
-                          onClick={() =>
-                            setEmojiPickerMsgId(
-                              emojiPickerMsgId === msg.id ? null : msg.id
-                            )
-                          }
-                        >
-                          <Smile className="h-3.5 w-3.5" />
-                        </Button>
-                        {isOwn && (
-                          <>
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              className="h-7 w-7"
-                              onClick={() => {
-                                setEditingId(msg.id);
-                                setEditContent(msg.content);
-                              }}
-                            >
-                              <Pencil className="h-3.5 w-3.5" />
-                            </Button>
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              className="h-7 w-7 text-destructive hover:text-destructive"
-                              onClick={() => handleDelete(msg.id)}
-                            >
-                              <Trash2 className="h-3.5 w-3.5" />
-                            </Button>
-                          </>
-                        )}
-                      </div>
+                  <div
+                    className={`max-w-[75%] relative ${
+                      isOwn ? "items-end" : "items-start"
+                    }`}
+                  >
+                    {!isOwn && !isGrouped && (
+                      <p className="text-xs text-muted-foreground mb-0.5">
+                        {name}
+                      </p>
                     )}
 
-                  {/* Message-level emoji picker (rendered only for active message) */}
-                  {emojiPickerMsgId === msg.id && (
-                    <div
-                      className={`absolute bottom-full mb-1 z-50 ${
-                        isOwn ? "right-0" : "left-0"
-                      }`}
-                    >
+                    {/* Action buttons */}
+                    {hoveredId === msg.id &&
+                      !isEditing &&
+                      !msg.is_deleted &&
+                      !msg.id.startsWith("temp-") && (
+                        <div
+                          className={`absolute -top-8 ${
+                            isOwn ? "right-0" : "left-0"
+                          } flex items-center gap-0.5 bg-background border rounded-md shadow-sm p-0.5 z-10`}
+                        >
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7"
+                            onClick={() =>
+                              setEmojiPickerMsgId(
+                                emojiPickerMsgId === msg.id ? null : msg.id
+                              )
+                            }
+                          >
+                            <Smile className="h-3.5 w-3.5" />
+                          </Button>
+                          {isOwn && (
+                            <>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-7 w-7"
+                                onClick={() => {
+                                  setEditingId(msg.id);
+                                  setEditContent(msg.content);
+                                }}
+                              >
+                                <Pencil className="h-3.5 w-3.5" />
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-7 w-7 text-destructive hover:text-destructive"
+                                onClick={() => handleDelete(msg.id)}
+                              >
+                                <Trash2 className="h-3.5 w-3.5" />
+                              </Button>
+                            </>
+                          )}
+                        </div>
+                      )}
+
+                    {/* Message-level emoji picker */}
+                    {emojiPickerMsgId === msg.id && (
+                      <div
+                        className={`absolute bottom-full mb-1 z-50 ${
+                          isOwn ? "right-0" : "left-0"
+                        }`}
+                      >
                         <EmojiPicker
                           onEmojiSelect={(emoji: { native: string }) =>
                             handleReaction(msg.id, emoji.native)
@@ -580,113 +658,136 @@ export function SessionChat({ sessionId, currentUserId }: SessionChatProps) {
                           previewPosition="none"
                           skinTonePosition="none"
                         />
-                    </div>
-                  )}
+                      </div>
+                    )}
 
-                  {/* Message bubble */}
-                  {msg.is_deleted ? (
-                    <div className="rounded-lg px-3 py-1.5 text-sm bg-muted italic text-muted-foreground">
-                      This message was deleted
-                    </div>
-                  ) : isEditing ? (
-                    <div className="flex items-center gap-1">
-                      <Input
-                        ref={editInputRef}
-                        value={editContent}
-                        onChange={(e) => setEditContent(e.target.value)}
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter") handleEdit(msg.id);
-                          if (e.key === "Escape") {
+                    {/* Message bubble */}
+                    {msg.is_deleted ? (
+                      <div className="rounded-lg px-3 py-1.5 text-sm bg-muted italic text-muted-foreground">
+                        This message was deleted
+                      </div>
+                    ) : isEditing ? (
+                      <div className="flex items-center gap-1">
+                        <Input
+                          ref={editInputRef}
+                          value={editContent}
+                          onChange={(e) => setEditContent(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") handleEdit(msg.id);
+                            if (e.key === "Escape") {
+                              setEditingId(null);
+                              setEditContent("");
+                            }
+                          }}
+                          className="text-sm h-8"
+                        />
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="h-7 w-7 shrink-0"
+                          onClick={() => handleEdit(msg.id)}
+                        >
+                          <Check className="h-3.5 w-3.5" />
+                        </Button>
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="h-7 w-7 shrink-0"
+                          onClick={() => {
                             setEditingId(null);
                             setEditContent("");
-                          }
-                        }}
-                        className="text-sm h-8"
-                      />
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        className="h-7 w-7 shrink-0"
-                        onClick={() => handleEdit(msg.id)}
-                      >
-                        <Check className="h-3.5 w-3.5" />
-                      </Button>
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        className="h-7 w-7 shrink-0"
-                        onClick={() => {
-                          setEditingId(null);
-                          setEditContent("");
-                        }}
-                      >
-                        <X className="h-3.5 w-3.5" />
-                      </Button>
-                    </div>
-                  ) : (
-                    <div
-                      className={`rounded-lg px-3 py-1.5 text-sm ${
-                        isOwn
-                          ? "bg-primary text-primary-foreground"
-                          : "bg-muted"
-                      }`}
-                    >
-                      {msg.content}
-                    </div>
-                  )}
-
-                  {/* Reactions */}
-                  {grouped.length > 0 && (
-                    <div className={`flex flex-wrap gap-1 mt-1 ${isOwn ? "justify-end" : ""}`}>
-                      {grouped.map((r) => (
-                        <button
-                          key={r.emoji}
-                          onClick={() => handleReaction(msg.id, r.emoji)}
-                          className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-xs border transition-colors ${
-                            r.userReacted
-                              ? "bg-primary/10 border-primary/30"
-                              : "bg-muted border-transparent hover:border-border"
-                          }`}
+                          }}
                         >
-                          <span>{r.emoji}</span>
-                          <span className="text-muted-foreground">{r.count}</span>
-                        </button>
-                      ))}
-                    </div>
-                  )}
+                          <X className="h-3.5 w-3.5" />
+                        </Button>
+                      </div>
+                    ) : (
+                      <div
+                        className={`rounded-lg px-3 py-1.5 text-sm whitespace-pre-wrap break-words ${
+                          isOwn
+                            ? "bg-emerald-600 text-white dark:bg-emerald-600"
+                            : "bg-muted"
+                        }`}
+                      >
+                        {msg.content}
+                      </div>
+                    )}
 
-                  {/* Timestamp + edited label */}
-                  {!isEditing && (
-                    <p className="text-[10px] text-muted-foreground mt-0.5">
-                      {formatDistanceToNow(new Date(msg.created_at), {
-                        addSuffix: true,
-                      })}
-                      {msg.is_edited && !msg.is_deleted && (
-                        <span className="ml-1">(edited)</span>
-                      )}
-                    </p>
-                  )}
+                    {/* Reactions */}
+                    {grouped.length > 0 && (
+                      <div className={`flex flex-wrap gap-1 mt-1 ${isOwn ? "justify-end" : ""}`}>
+                        {grouped.map((r) => (
+                          <button
+                            key={r.emoji}
+                            onClick={() => handleReaction(msg.id, r.emoji)}
+                            className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-xs border transition-colors ${
+                              r.userReacted
+                                ? "bg-primary/10 border-primary/30"
+                                : "bg-muted border-transparent hover:border-border"
+                            }`}
+                          >
+                            <span>{r.emoji}</span>
+                            <span className="text-muted-foreground">{r.count}</span>
+                          </button>
+                        ))}
+                      </div>
+                    )}
+
+                    {/* Timestamp — hidden on grouped messages unless hovered */}
+                    {!isEditing && (!isGrouped || hoveredId === msg.id) && (
+                      <p className="text-[10px] text-muted-foreground mt-0.5">
+                        {formatDistanceToNow(new Date(msg.created_at), {
+                          addSuffix: true,
+                        })}
+                        {msg.is_edited && !msg.is_deleted && (
+                          <span className="ml-1">(edited)</span>
+                        )}
+                      </p>
+                    )}
+                  </div>
                 </div>
-              </div>
-            );
-          })}
-          <div ref={messagesEndRef} />
+              );
+            })}
+            <div ref={messagesEndRef} />
+          </div>
+
+          {/* Jump to bottom button */}
+          {isScrolledUp && (
+            <div className="absolute bottom-5 left-0 right-0 flex justify-center pointer-events-none z-10">
+              <button
+                onClick={handleScrollToBottom}
+                className="pointer-events-auto flex items-center gap-1.5 bg-emerald-600 text-white text-xs px-3 py-1.5 rounded-full shadow-lg hover:bg-emerald-700 transition-colors"
+              >
+                <ChevronDown className="h-3.5 w-3.5" />
+                {newMsgCount > 0
+                  ? `${newMsgCount} new ${newMsgCount === 1 ? "message" : "messages"}`
+                  : "Scroll to bottom"}
+              </button>
+            </div>
+          )}
         </div>
+
+        {/* Typing indicator */}
+        {typingCount > 0 && (
+          <p className="text-xs text-muted-foreground italic mb-2">
+            {typingCount === 1 ? "Someone is typing..." : `${typingCount} people are typing...`}
+          </p>
+        )}
 
         {/* Input */}
         <div className="relative">
           {showInputEmoji && (
             <div className="absolute bottom-full mb-2 left-0 z-50">
-                <EmojiPicker
-                  onEmojiSelect={(emoji: { native: string }) => {
-                    setNewMessage((prev) => prev + emoji.native);
-                    setShowInputEmoji(false);
-                    inputRef.current?.focus();
-                  }}
-                  theme="auto"
-                  previewPosition="none"
-                  skinTonePosition="none"
-                />
+              <EmojiPicker
+                onEmojiSelect={(emoji: { native: string }) => {
+                  setNewMessage((prev) => prev + emoji.native);
+                  setShowInputEmoji(false);
+                  inputRef.current?.focus();
+                }}
+                theme="auto"
+                previewPosition="none"
+                skinTonePosition="none"
+              />
             </div>
           )}
           <form onSubmit={handleSend} className="flex gap-2 items-center">
@@ -702,14 +803,35 @@ export function SessionChat({ sessionId, currentUserId }: SessionChatProps) {
             <Input
               ref={inputRef}
               value={newMessage}
-              onChange={(e) => setNewMessage(e.target.value)}
+              onChange={(e) => {
+                const value = e.target.value;
+                setNewMessage(value);
+                // Typing indicator via presence
+                if (channelRef.current) {
+                  channelRef.current.track({ userId: currentUserId, typing: true });
+                  if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
+                  typingTimeoutRef.current = setTimeout(() => {
+                    channelRef.current?.track({ userId: currentUserId, typing: false });
+                  }, 2000);
+                }
+              }}
               placeholder="Type a message..."
               disabled={sending}
+              maxLength={2000}
             />
             <Button type="submit" size="icon" disabled={sending || !newMessage.trim()}>
               <Send className="h-4 w-4" />
             </Button>
           </form>
+          {charsLeft <= 400 && (
+            <p
+              className={`text-[10px] text-right mt-1 ${
+                charsLeft <= 100 ? "text-destructive" : "text-muted-foreground"
+              }`}
+            >
+              {charsLeft} remaining
+            </p>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/src/lib/actions/messages.ts
+++ b/src/lib/actions/messages.ts
@@ -5,6 +5,8 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { revalidatePath } from "next/cache";
 import { after } from "next/server";
 
+const MAX_MESSAGE_LENGTH = 2000;
+
 export async function sendSessionMessage(sessionId: string, content: string) {
   const supabase = await createClient();
   const {
@@ -15,6 +17,8 @@ export async function sendSessionMessage(sessionId: string, content: string) {
 
   const trimmed = content.trim();
   if (!trimmed) throw new Error("Message cannot be empty");
+  if (trimmed.length > MAX_MESSAGE_LENGTH)
+    throw new Error(`Message cannot exceed ${MAX_MESSAGE_LENGTH} characters`);
 
   const { error } = await supabase.from("session_messages").insert({
     session_id: sessionId,
@@ -37,6 +41,8 @@ export async function sendDirectMessage(receiverId: string, content: string) {
 
   const trimmed = content.trim();
   if (!trimmed) throw new Error("Message cannot be empty");
+  if (trimmed.length > MAX_MESSAGE_LENGTH)
+    throw new Error(`Message cannot exceed ${MAX_MESSAGE_LENGTH} characters`);
 
   const { error } = await supabase.from("direct_messages").insert({
     sender_id: user.id,
@@ -60,6 +66,16 @@ export async function editDirectMessage(messageId: string, newContent: string) {
 
   const trimmed = newContent.trim();
   if (!trimmed) throw new Error("Message cannot be empty");
+  if (trimmed.length > MAX_MESSAGE_LENGTH)
+    throw new Error(`Message cannot exceed ${MAX_MESSAGE_LENGTH} characters`);
+
+  // Fetch receiver before update so we can revalidate their conversation path
+  const { data: existing } = await supabase
+    .from("direct_messages")
+    .select("receiver_id")
+    .eq("id", messageId)
+    .eq("sender_id", user.id)
+    .single();
 
   const { error } = await supabase
     .from("direct_messages")
@@ -70,6 +86,7 @@ export async function editDirectMessage(messageId: string, newContent: string) {
   if (error) throw new Error(error.message);
 
   revalidatePath("/messages");
+  if (existing) revalidatePath(`/messages/${existing.receiver_id}`);
 }
 
 export async function deleteDirectMessage(messageId: string) {
@@ -93,7 +110,8 @@ export async function deleteDirectMessage(messageId: string) {
 
 export async function editSessionMessage(
   messageId: string,
-  newContent: string
+  newContent: string,
+  sessionId: string
 ) {
   const supabase = await createClient();
   const {
@@ -104,6 +122,8 @@ export async function editSessionMessage(
 
   const trimmed = newContent.trim();
   if (!trimmed) throw new Error("Message cannot be empty");
+  if (trimmed.length > MAX_MESSAGE_LENGTH)
+    throw new Error(`Message cannot exceed ${MAX_MESSAGE_LENGTH} characters`);
 
   const { error } = await supabase
     .from("session_messages")
@@ -112,9 +132,11 @@ export async function editSessionMessage(
     .eq("user_id", user.id);
 
   if (error) throw new Error(error.message);
+
+  revalidatePath(`/sessions/${sessionId}`);
 }
 
-export async function deleteSessionMessage(messageId: string) {
+export async function deleteSessionMessage(messageId: string, sessionId: string) {
   const supabase = await createClient();
   const {
     data: { user },
@@ -129,6 +151,8 @@ export async function deleteSessionMessage(messageId: string) {
     .eq("user_id", user.id);
 
   if (error) throw new Error(error.message);
+
+  revalidatePath(`/sessions/${sessionId}`);
 }
 
 export async function sendGroupMessage(
@@ -145,6 +169,8 @@ export async function sendGroupMessage(
 
   const trimmed = content.trim();
   if (!trimmed) throw new Error("Message cannot be empty");
+  if (trimmed.length > MAX_MESSAGE_LENGTH)
+    throw new Error(`Message cannot exceed ${MAX_MESSAGE_LENGTH} characters`);
 
   const { error } = await supabase.from("group_messages").insert({
     group_id: groupId,
@@ -220,7 +246,11 @@ export async function sendGroupMessage(
   });
 }
 
-export async function editGroupMessage(messageId: string, newContent: string) {
+export async function editGroupMessage(
+  messageId: string,
+  newContent: string,
+  groupId: string
+) {
   const supabase = await createClient();
   const {
     data: { user },
@@ -230,6 +260,8 @@ export async function editGroupMessage(messageId: string, newContent: string) {
 
   const trimmed = newContent.trim();
   if (!trimmed) throw new Error("Message cannot be empty");
+  if (trimmed.length > MAX_MESSAGE_LENGTH)
+    throw new Error(`Message cannot exceed ${MAX_MESSAGE_LENGTH} characters`);
 
   const { error } = await supabase
     .from("group_messages")
@@ -238,9 +270,11 @@ export async function editGroupMessage(messageId: string, newContent: string) {
     .eq("user_id", user.id);
 
   if (error) throw new Error(error.message);
+
+  revalidatePath(`/groups/${groupId}`);
 }
 
-export async function deleteGroupMessage(messageId: string) {
+export async function deleteGroupMessage(messageId: string, groupId: string) {
   const supabase = await createClient();
   const {
     data: { user },
@@ -255,6 +289,8 @@ export async function deleteGroupMessage(messageId: string) {
     .eq("user_id", user.id);
 
   if (error) throw new Error(error.message);
+
+  revalidatePath(`/groups/${groupId}`);
 }
 
 export async function toggleReaction(


### PR DESCRIPTION
## Summary

- Fixed 5 server-side bugs in chat actions (missing `revalidatePath`, missing `sessionId`/`groupId` params, no message length enforcement)
- Added real-time typing indicators via Supabase Presence across all three chat surfaces
- Added jump-to-bottom button with unread count badge
- Added message grouping (consecutive messages from same user collapse avatar/name/timestamp)
- Added auto-growing textarea compose area with Enter-to-send / Shift+Enter-for-newline
- Added date separators between messages from different days
- Fixed own message bubble color — was rendering grey in dark mode due to `bg-primary` mapping; now hardcoded `bg-emerald-600`
- Added `whitespace-pre-wrap` so multiline messages render correctly
- Added sending state opacity (`opacity-60`) on optimistic messages
- Added subtle background textures: diagonal stripe wallpaper for chat areas, dot grid for all other pages

## Bug fixes

| Bug | Fix |
|---|---|
| `editDirectMessage` missing `revalidatePath` for recipient | Fetch `receiver_id` before update, then call `revalidatePath(/messages/${receiverId})` |
| `editSessionMessage` / `deleteSessionMessage` had no `revalidatePath` | Added `sessionId` param + `revalidatePath(/sessions/${sessionId})` |
| `editGroupMessage` / `deleteGroupMessage` had no `revalidatePath` | Added `groupId` param + `revalidatePath(/groups/${groupId})` |
| `MAX_MESSAGE_LENGTH` only enforced on client | Now validated server-side in all 6 send/edit actions |
| `/messages/[userId]` crashed when `userId === currentUser.id` | Added redirect to `/messages` |
| All chats scrolled to bottom on every message update | Fixed with `hasInitialScrolledRef` — instant jump on load, near-bottom check on new messages |
| 5s polling running alongside Realtime | Extended to 30s safety-net fallback |

## Test plan

- [ ] Send a message in group chat — bubble appears in emerald green for sender, grey for others
- [ ] Send a message in DM — same colour behaviour
- [ ] Edit a message in group chat — other members see the update without refresh
- [ ] Delete a message in session chat — update reflected without refresh
- [ ] Type in group chat — other members see typing indicator; it clears after 2s idle and immediately on send
- [ ] Type in DM — other user sees `"typing..."` under their name in the header
- [ ] Send several consecutive messages — avatar/name/timestamp collapse into grouped view
- [ ] Send messages across midnight — date separator appears between the two days
- [ ] Write a multi-line message with Shift+Enter — compose box grows, newlines render in the bubble
- [ ] Scroll up in a busy chat — jump-to-bottom pill appears; new messages increment the badge; clicking it returns to bottom
- [ ] Open any protected page in light and dark mode — faint dot-grid texture visible in page background
- [ ] Open any chat in light and dark mode — faint diagonal stripe texture visible in message area

🤖 Generated with [Claude Code](https://claude.com/claude-code)
